### PR TITLE
latex: clean example and template headers

### DIFF
--- a/exercises-latex/04-titlepage/loesung.tex
+++ b/exercises-latex/04-titlepage/loesung.tex
@@ -1,4 +1,6 @@
-\documentclass[titlepage=firstiscover]{scrartcl}
+\documentclass[
+  titlepage=firstiscover,
+]{scrartcl}
 
 \usepackage[aux]{rerunfilecheck}
 

--- a/exercises-latex/05-structure/loesung.tex
+++ b/exercises-latex/05-structure/loesung.tex
@@ -1,4 +1,6 @@
-\documentclass[titlepage=firstiscover]{scrartcl}
+\documentclass[
+  titlepage=firstiscover,
+]{scrartcl}
 
 \usepackage[aux]{rerunfilecheck}
 

--- a/exercises-latex/06-math/loesung.tex
+++ b/exercises-latex/06-math/loesung.tex
@@ -19,6 +19,8 @@
   partial=upright,
 ]{unicode-math}
 
+\setmathfont{Latin Modern Math}
+
 \usepackage[unicode]{hyperref}
 \usepackage{bookmark}
 

--- a/exercises-latex/08-figures/loesung.tex
+++ b/exercises-latex/08-figures/loesung.tex
@@ -8,17 +8,20 @@
 \usepackage{fontspec}
 
 \usepackage[
+  section,
+  below,
+]{placeins}
+
+\usepackage[
   labelfont=bf,
   font=small,
   width=0.9\textwidth,
 ]{caption}
-
 \usepackage{subcaption}
 
 \usepackage{graphicx}
 \usepackage{grffile}
 
-\usepackage[section, below]{placeins}
 \usepackage{float}
 \floatplacement{figure}{htbp}
 

--- a/exercises-latex/10-references/loesung.tex
+++ b/exercises-latex/10-references/loesung.tex
@@ -1,4 +1,6 @@
-\documentclass[captions=tableheading]{scrartcl}
+\documentclass[
+  captions=tableheading,
+]{scrartcl}
 
 \usepackage[aux]{rerunfilecheck}
 
@@ -6,17 +8,22 @@
 \setmainlanguage{german}
 
 \usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{mathtools}
 
 \usepackage{fontspec}
 
 \usepackage{float}
-\usepackage[section, below]{placeins}
+\floatplacement{figure}{htbp}
+\floatplacement{table}{htbp}
+
+\usepackage[
+  section,
+  below,
+]{placeins}
 
 \usepackage[unicode]{hyperref}
 \usepackage{bookmark}
-
-\floatplacement{figure}{htbp}
-\floatplacement{table}{htbp}
 
 \begin{document}
 

--- a/exercises-latex/11-biblatex/loesung.tex
+++ b/exercises-latex/11-biblatex/loesung.tex
@@ -5,7 +5,9 @@
 \usepackage{polyglossia}
 \setmainlanguage{german}
 
-\usepackage[style=alphabetic]{biblatex}
+\usepackage[
+  style=alphabetic,
+]{biblatex}
 
 \usepackage{fontspec}
 

--- a/latex-template/header.tex
+++ b/latex-template/header.tex
@@ -20,37 +20,57 @@
 
 % Fonteinstellungen
 \usepackage{fontspec}
-\defaultfontfeatures{Ligatures=TeX}
 
 \usepackage[
-  math-style=ISO,    % \
-  bold-style=ISO,    % |
-  sans-style=italic, % | ISO-Standard folgen
-  nabla=upright,     % |
-  partial=upright,   % /
+  math-style=ISO,    % ┐
+  bold-style=ISO,    % │
+  sans-style=italic, % │ ISO-Standard folgen
+  nabla=upright,     % │
+  partial=upright,   % ┘
+  warnings-off={           % ┐
+    mathtools-colon,       % │ unnötige Warnungen ausschalten
+    mathtools-overbracket, % │
+  },                       % ┘
 ]{unicode-math}
 
 \setmathfont{Latin Modern Math}
-\setmathfont[range={\mathscr, \mathbfscr}]{XITS Math}
+\setmathfont{XITS Math}[range={scr, bfscr}]
+\setmathfont{XITS Math}[range={cal, bfcal}, StylisticSet=1]
+
+% Zahlen und Einheiten
+\usepackage[
+  locale=DE,                 % deutsche Einstellungen
+  separate-uncertainty=true, % immer Fehler mit \pm
+  per-mode=reciprocal,       % ^-1 für inverse Einheiten
+]{siunitx}
+
+% chemische Formeln
+\usepackage[
+  version=4,
+  math-greek=default, % ┐ mit unicode-math zusammenarbeiten
+  text-greek=default, % ┘
+]{mhchem}
 
 % richtige Anführungszeichen
 \usepackage[autostyle]{csquotes}
 
-% Zahlen und Einheiten
-\usepackage[
-  locale=DE,                   % deutsche Einstellungen
-  separate-uncertainty=true,   % Immer Fehler mit \pm
-  per-mode=symbol-or-fraction, % m/s im Text, sonst Brüche
-]{siunitx}
-
-% chemische Formeln
-\usepackage[version=3]{mhchem}
-
 % schöne Brüche im Text
 \usepackage{xfrac}
 
+% Standardplatzierung für Floats einstellen
+\usepackage{float}
+\floatplacement{figure}{htbp}
+\floatplacement{table}{htbp}
+
 % Floats innerhalb einer Section halten
-\usepackage[section, below]{placeins}
+\usepackage[
+  section, % Floats innerhalb der Section halten
+  below,   % unterhalb der Section aber auf der selben Seite ist ok
+]{placeins}
+
+% Seite drehen für breite Tabellen
+\usepackage{pdflscape}
+
 % Captions schöner machen.
 \usepackage[
   labelfont=bf,        % Tabelle x: Abbildung y: ist jetzt fett
@@ -65,29 +85,23 @@
 % größere Variation von Dateinamen möglich
 \usepackage{grffile}
 
-% Standardplatzierung für Floats einstellen
-\usepackage{float}
-\floatplacement{figure}{htbp}
-\floatplacement{table}{htbp}
-
 % schöne Tabellen
 \usepackage{booktabs}
 
-% Seite drehen für breite Tabellen
-\usepackage{pdflscape}
-
 % Literaturverzeichnis
-\usepackage{biblatex}
+\usepackage[
+  backend=biber,
+]{biblatex}
 % Quellendatenbank
 \addbibresource{lit.bib}
 \addbibresource{programme.bib}
 
 % Hyperlinks im Dokument
 \usepackage[
-  unicode,
+  unicode,        % Unicode in PDF-Attributen erlauben
   pdfusetitle,    % Titel, Autoren und Datum als PDF-Attribute
-  pdfcreator={},  % PDF-Attribute säubern
-  pdfproducer={}, % "
+  pdfcreator={},  % ┐ PDF-Attribute säubern
+  pdfproducer={}, % ┘
 ]{hyperref}
 % erweiterte Bookmarks im PDF
 \usepackage{bookmark}
@@ -102,10 +116,10 @@
     \href{mailto:authorA@udo.edu}{authorA@udo.edu}
   }{}%
   \texorpdfstring{\and}{, }
-  AUTOR B
+  AUTOR B%
   \texorpdfstring{
     \\
     \href{mailto:authorB@udo.edu}{authorB@udo.edu}
-  }{}
+  }{}%
 }
 \publishers{TU Dortmund – Fakultät Physik}


### PR DESCRIPTION
`\defaultfontfeatures`: das ist mittlerweile standard für `rm` und `sf`, aber nicht `tt`, genau wie wir es haben wollen.