### PR TITLE
LaTeX-Option für matplotlib hinzugefügt

### DIFF
--- a/python/matplotlib.ipynb
+++ b/python/matplotlib.ipynb
@@ -629,6 +629,28 @@
     "\n",
     "fig.tight_layout()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h1> LaTeX </h1>\n",
+    "<b1> Es ist auch möglich LaTeX für das Setzen aller Plot-Beschriftungen (d.h. Achsenbeschriftungen, Ticks, Legenden, usw.) zu verwenden. Zum Ausprobieren, können die obigen Plots mit der Option unten neu erstellt werden. </b1>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib as mpl\n",
+    "\n",
+    "mpl.rc('font', **{'family': 'serif', 'serif': ['Computer Modern']})\n",
+    "mpl.rc('text', usetex=True)"
+   ]
   }
  ],
  "metadata": {

--- a/python/matplotlib.ipynb
+++ b/python/matplotlib.ipynb
@@ -635,7 +635,7 @@
    "metadata": {},
    "source": [
     "<h1> LaTeX </h1>\n",
-    "<b1> Es ist auch möglich LaTeX für das Setzen aller Plot-Beschriftungen (d.h. Achsenbeschriftungen, Ticks, Legenden, usw.) zu verwenden. Zum Ausprobieren, können die obigen Plots mit der Option unten neu erstellt werden. </b1>"
+    "<b1> Es ist auch möglich LaTeX für das Setzen aller Plot-Beschriftungen (d.h. Achsenbeschriftungen, Ticks, Legenden, usw.) zu verwenden. Seht Euch dazu die \"TeX in matplotlib\" Folien an. </b1>"
    ]
   },
   {
@@ -645,12 +645,7 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": [
-    "import matplotlib as mpl\n",
-    "\n",
-    "mpl.rc('font', **{'family': 'serif', 'serif': ['Computer Modern']})\n",
-    "mpl.rc('text', usetex=True)"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/python/matplotlib.ipynb
+++ b/python/matplotlib.ipynb
@@ -637,15 +637,6 @@
     "<h1> LaTeX </h1>\n",
     "<b1> Es ist auch möglich LaTeX für das Setzen aller Plot-Beschriftungen (d.h. Achsenbeschriftungen, Ticks, Legenden, usw.) zu verwenden. Seht Euch dazu die \"TeX in matplotlib\" Folien an. </b1>"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
In matplotlib.ipynb habe ich der letzten Zelle die Option hinzugefügt LaTeX für das Setzen aller Beschriftungen zu verwenden, da ich das immer benutze. 