### PR TITLE
added an example for nested f-strings

### DIFF
--- a/python/python.ipynb
+++ b/python/python.ipynb
@@ -1450,7 +1450,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "first_value = 42\n",
@@ -1474,12 +1476,35 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "result = 3.2291421\n",
     "\n",
     "print(f'Das Ergebnis ist {result:.2f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Man kann die Variablen in _f-strings_ auch verschachteln.   \n",
+    "Zum Beispiel kann man die Genauigkeit für `floats` auch als Variable angeben:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = 3.2291421\n",
+    "precisions = [1,2,3,4,5]\n",
+    "\n",
+    "for precision in precisions:\n",
+    "    print(f'Das Ergebnis ist {result:.{precision}f}')"
    ]
   },
   {
@@ -1518,7 +1543,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "'Das Ergebnis ist {result:.2f} und damit kleiner als {four}'.format(result=3.2291421, four=4)"
@@ -1536,7 +1563,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(r'\\SI{{{:.4f}}}{{{:s}}}'.format(1.23456, r'\\kilo\\joule'))"
@@ -1552,7 +1581,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(r'\\SI {{ {:.4f} }} {{ {:s} }}'.format(1.23456, r'\\kilo\\joule'))"

--- a/python/python.ipynb
+++ b/python/python.ipynb
@@ -849,7 +849,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Die Reihenfolge der Einträge entspricht nicht notwendigerweise der Zuweisungsreihenfolge!"
+    "In der aktuellen Python-Version 3.6 entspricht die Reihenfolge der Einträge in Dictionaries der   \n",
+    "Zuweisungsreihenfolge! In allen älteren Versionen war dies nicht der Fall und es kann sich auch   \n",
+    "wieder ändern. $\\Rightarrow$ Nicht auf die Reihenfolge der Dictionary-Einträge verlassen."
    ]
   },
   {
@@ -1497,7 +1499,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "result = 3.2291421\n",


### PR DESCRIPTION
The example shows that you can use an other variable
to set the precision of a float.

Changed comment on the order of dictionaries, which has changed since last year.