### PR TITLE
splited scientific-python notebook

### DIFF
--- a/python/numeric-python.ipynb
+++ b/python/numeric-python.ipynb
@@ -53,7 +53,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "2 * x"
@@ -62,7 +64,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "x**2"
@@ -71,7 +75,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "x**x"
@@ -80,7 +86,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.cos(x)"
@@ -96,7 +104,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import math\n",
@@ -113,7 +123,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def poly(y):\n",
@@ -125,7 +137,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "poly(np.pi)"
@@ -134,7 +148,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# this also works:\n",
@@ -156,7 +172,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# two-dimensional array\n",
@@ -179,7 +197,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.zeros(10)"
@@ -188,7 +208,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.ones((5, 2))"
@@ -197,7 +219,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.linspace(0, 1, 11)"
@@ -206,7 +230,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# like range() for arrays:\n",
@@ -216,7 +242,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.logspace(-4, 5, 10)"
@@ -234,7 +262,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "x = np.arange(0, 10)\n",
@@ -246,7 +276,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# all elements with indices ≥1 and <4:\n",
@@ -256,7 +288,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# negative indices count from the end\n",
@@ -266,7 +300,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# combination:\n",
@@ -276,7 +312,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# step size\n",
@@ -286,7 +324,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# trick for reversal: negative step\n",
@@ -296,7 +336,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "y = np.array([x, x + 10, x + 20, x + 30])\n",
@@ -306,7 +348,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# comma between indices\n",
@@ -316,7 +360,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# only one index ⇒ one-dimensional array\n",
@@ -326,7 +372,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# other axis: (: alone means the whole axis)\n",
@@ -336,7 +384,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# inspecting the number of elements per axis:\n",
@@ -353,7 +403,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "y"
@@ -362,7 +414,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "y[:, 3] = 0\n",
@@ -379,7 +433,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "y[:,0] = x[3:7]\n",
@@ -396,7 +452,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "y"
@@ -405,7 +463,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "y.shape"
@@ -414,7 +474,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "y.T"
@@ -423,7 +485,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "y.T.shape"
@@ -444,7 +508,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "a = np.linspace(0, 2, 11)\n",
@@ -467,7 +533,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "x"
@@ -476,7 +544,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.sum(x)"
@@ -485,7 +555,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.prod(x)"
@@ -494,7 +566,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.mean(x)"
@@ -510,7 +584,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.std(x)"
@@ -526,7 +602,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.std(x, ddof=1) / np.sqrt(len(x))"
@@ -542,7 +620,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.std(x, ddof=1)"
@@ -558,7 +638,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "z = x**2\n",
@@ -581,7 +663,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "n = np.arange(11)\n",
@@ -596,7 +680,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "data = np.array([n, x])\n",
@@ -617,7 +703,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "n = np.arange(11)\n",
@@ -639,382 +727,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "a, b = np.genfromtxt('test.txt', unpack=True)\n",
     "a, b"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# SciPy\n",
-    "![SciPy](https://raw.githubusercontent.com/scipy/scipy-sphinx-theme/master/_static/scipyshiny_small.png)\n",
-    "\n",
-    "- Baut auf NumPy auf\n",
-    "- Kann numerisch integrieren, DGLs lösen, optimieren, minimieren, …\n",
-    "- Enthält auch physikalische Konstanten und wichtige mathematische Funktionen"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# standard error of the mean\n",
-    "from scipy.stats import sem\n",
-    "sem(x)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# physical constants\n",
-    "import scipy.constants as const\n",
-    "const.epsilon_0"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# convert temperatures:\n",
-    "print(const.C2K(100))\n",
-    "print(const.K2C(100))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# convert angles:\n",
-    "print(np.rad2deg(np.pi))\n",
-    "print(np.deg2rad(90))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# more constants (including units and errors)!\n",
-    "list(const.physical_constants.items())[:10]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Achtung\n",
-    "Wenn solche Konstanten genutzt werden, muss das korrekt mitgeteilt, also zitiert werden.\n",
-    "Darauf gehen wir nächste Woche im LaTeX-Workshop ein :-)\n",
-    "\n",
-    "(Quelle hier: *python-scipy*)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "const.physical_constants[\"proton mass\"]\n",
-    "# value, unit, error"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Fitten\n",
-    "Oft möchte man eine Funktion, zum Beispiel eine Erwartung aus der Theorie, an die gemessenen Werte anpassen.\n",
-    "Dies nennt man Fit."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# fit arbitrary functions\n",
-    "from scipy.optimize import curve_fit\n",
-    "\n",
-    "x, y = np.genfromtxt('example_data.txt', unpack=True)\n",
-    "\n",
-    "def f(x, a, b):\n",
-    "    return a * x + b\n",
-    "\n",
-    "params, covariance_matrix = curve_fit(f, x, y)\n",
-    "\n",
-    "errors = np.sqrt(np.diag(covariance_matrix))\n",
-    "\n",
-    "print('a =', params[0], '±', errors[0])\n",
-    "print('b =', params[1], '±', errors[1])\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# prepare plot\n",
-    "%matplotlib inline\n",
-    "import matplotlib.pyplot as plt\n",
-    "plt.rcParams['figure.figsize'] = (10, 8)\n",
-    "plt.rcParams['font.size'] = 16\n",
-    "\n",
-    "\n",
-    "x_plot = np.linspace(0, 10)\n",
-    "\n",
-    "plt.plot(x, y, 'k.', label=\"example data\")\n",
-    "plt.plot(x_plot, f(x_plot, *params), 'r-', label='linearer Fit', linewidth=3)\n",
-    "plt.legend(loc=\"best\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    "Da ein Fit mit `curve_fit()` intern ein Minimierungsalgorithmus ist, hängt   \n",
-    "das Ergebnis unter Umständen von den Anfangsbedingungen ab."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Fit einer komplexeren Funktion: Sigmoidfunktion\n",
-    "(Ähnlich zum `tanh`)\n",
-    "\n",
-    "$$ f(x; a, b, c) = \\frac{a}{1 + \\exp(-(x-b))} + c$$"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def sigmoid(x, a, b, c):\n",
-    "    y = a / (1 + np.exp(-(x-b))) + c\n",
-    "    return y\n",
-    "\n",
-    "x_plot = np.linspace(-50, 50, 1000)\n",
-    "\n",
-    "plt.xlabel('x')\n",
-    "plt.ylabel('y')\n",
-    "\n",
-    "plt.plot(x_plot, sigmoid(x_plot, 1, 0, 0), label=\"Sigmoid\")\n",
-    "plt.plot(x_plot, np.tanh(x_plot), label=\"tanh\")\n",
-    "plt.legend()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Die Messwerte aus einem Praktikumsversuch:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x, y = np.loadtxt('fit_data_with_init_values.txt', unpack=True)\n",
-    "\n",
-    "plt.plot(x, y, 'ro', label=r'Messwerte')\n",
-    "\n",
-    "plt.xlabel('Temperatur / °C')\n",
-    "plt.ylabel('$GP$')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Ein einfacher Fit wie oben funktioniert hier nicht so gut:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "params, covariance_matrix = curve_fit(sigmoid, x, y)\n",
-    "\n",
-    "errors = np.sqrt(np.diag(covariance_matrix))\n",
-    "\n",
-    "print('a =', params[0], '±', errors[0])\n",
-    "print('b =', params[1], '±', errors[1])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Schaut man sich die berechnete Ausgleichskurve an sieht man auch,   \n",
-    "dass das nicht stimmen kann:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.xlabel('Temperatur / °C')\n",
-    "plt.ylabel('$GP$')\n",
-    "\n",
-    "plt.plot(x, y, 'ro', label='Messdaten')\n",
-    "plt.plot(x_plot, sigmoid(x_plot, *params), \"b-\", label=r'Sigmoid Fit')\n",
-    "\n",
-    "plt.legend(loc='best')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Was macht man jetzt?**   \n",
-    "Bei solchen Fragen hilft die Dokumentation der Pythonmodule (hier: scipy) oder _Stackoverflow_ weiter.   \n",
-    "Folgendes _Google-Muster_ ist ein guter Anfang (beachte englische Sprache):  \n",
-    "\n",
-    "    python <module-name> <function-name> <What went wrong?>\n",
-    "\n",
-    "Also in diesem Fall: `python scipy curve_fit fails`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Damit dieser Fit funktioniert müssen die Startwerte für den internen   \n",
-    "Minimierungsalgorithmus angepasst werden.  \n",
-    "Aus der Dokumentation/Stackoverflow wissen wir jetzt, dass man mit dem   \n",
-    "_keyword argument_ `p0` (Standardwert is `p0=(1,1,1)`) die Startwerte einstellt:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "params, covariance_matrix = curve_fit(sigmoid, x, y, p0=(-1, 40, 1))\n",
-    "\n",
-    "errors = np.sqrt(np.diag(covariance_matrix))\n",
-    "\n",
-    "print('a =', params[0], '±', errors[0])\n",
-    "print('b =', params[1], '±', errors[1])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.xlabel('Temperatur / °C')\n",
-    "plt.ylabel('$GP$')\n",
-    "\n",
-    "x_plot = np.linspace(0, 50, 1000)\n",
-    "\n",
-    "plt.plot(x, y, 'ro', label='Messwerte')\n",
-    "plt.plot(x_plot, sigmoid(x_plot, *params), \"b-\", label='Sigmoid Fit')\n",
-    "\n",
-    "plt.legend(loc='best')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Zum Vergleich der beiden Anfangswerte (seeds) kann man sich die einmal ansehen   \n",
-    "und mit den angepassten Parametern vergleichen:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "default_seed = (1,1,1)\n",
-    "good_seed = (-1,40,1)\n",
-    "\n",
-    "parameter = [default_seed, good_seed, params]\n",
-    "\n",
-    "x_plot = np.linspace(-80, 80, 1000)\n",
-    "\n",
-    "for p in parameter:\n",
-    "    plt.plot(x_plot, sigmoid(x_plot, *p),  label=\"f(x; {0:0.3f}, {1:0.3f}, {2:0.3f})\".format(*p))\n",
-    "    \n",
-    "plt.legend()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Die richtigen Startwerte findet man entweder durch \n",
-    "\n",
-    "1. _trial and error_ => einfach ausprobieren bis es klappt\n",
-    "\n",
-    "2. _nachdenken_ => siehe unten\n",
-    "    \n",
-    "Im obigen Beispiel musste nur Parameter `b` angepasst werden,   \n",
-    "weil der für die Form der Kurve sehr wichtig ist.\n",
-    "\n",
-    "$$ f(x; a, b, c) = \\frac{a}{1 + \\exp(-(x-b))} + c$$"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "B = [0, 20, 40]\n",
-    "\n",
-    "x_plot = np.linspace(-50, 50, 1000)\n",
-    "\n",
-    "plt.xlabel('x')\n",
-    "plt.ylabel('y')\n",
-    "\n",
-    "\n",
-    "for b in B:\n",
-    "    \n",
-    "    line = plt.plot(x_plot, sigmoid(x_plot, 1, b, 0),  label=f\"f(x; 1, {b}, 0)\")\n",
-    "    plt.plot(b, sigmoid(b, 1, b, 0), \"o\", color=line[0].get_color(), ms=20, label=f\"f(x={b}) = {sigmoid(b, 1, b, 0)}\")\n",
-    "    \n",
-    "\n",
-    "plt.legend()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Der Parameter $b$ gibt den $x$-Wert an bei dem die Funktion auf die Hälfte des Maximums abgefallen ist.   \n",
-    "Bei den Messwerten oben ist die Stelle ungefähr bei $x=40$ also ist `b=40` ein guter Startwert."
    ]
   }
  ],

--- a/python/numeric-python.ipynb
+++ b/python/numeric-python.ipynb
@@ -1,0 +1,1043 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "# ![Numpy](http://www.numpy.org/_static/numpy_logo.png)\n",
+    "\n",
+    "- Meist hat man nach in einer Auswertung Datenpunkte, die verarbeitet werden müssen\n",
+    "- Numpy ist eine Python-Bibliothek, die den Umgang mit Datenpunkten enorm vereinfacht"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Grunddatentyp von Numpy: das Array\n",
+    "- Kann man sich als effizientere Liste vorstellen\n",
+    "- Idee von Numpy: Man kann ein Array ähnlich wie eine Zahl verwenden. Operationen werden dann auf allen Elementen ausgeführt\n",
+    "- Am besten versteht man das mit einigen Beispielen:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# convert list to array\n",
+    "x = np.array([1, 2, 3, 4, 5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "2 * x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x**2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x**x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.cos(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Achtung: Man braucht das `cos` aus numpy!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "math.cos(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Selbstgeschriebene Funktionen, die nur für eine Zahl geschrieben wurden, funktionieren oft ohne Änderung mit Arrays!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def poly(y):\n",
+    "    return y + 2 * y**2 - y**3\n",
+    "\n",
+    "poly(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poly(np.pi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this also works:\n",
+    "def poly(x):\n",
+    "    return x + 2 * x**2 - x**3\n",
+    "\n",
+    "poly(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Das erlaubt es einem unter anderem sehr leicht physikalische Formeln auf seine Datenpunkte anzuwenden.\n",
+    "\n",
+    "Arrays können beliebige Dimension haben:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# two-dimensional array\n",
+    "y = np.array([[1, 2, 3],\n",
+    "              [4, 5, 6],\n",
+    "              [7, 8, 9]])\n",
+    "\n",
+    "y + y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Das erlaubt es z.B. eine ganze Tabelle als ein Array abzuspeichern.\n",
+    "\n",
+    "Es gibt viele nützliche Funktionen, die bei der Erstellung von Arrays helfen:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.zeros(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.ones((5, 2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.linspace(0, 1, 11)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# like range() for arrays:\n",
+    "np.arange(0, 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.logspace(-4, 5, 10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Numpy Indexing\n",
+    "\n",
+    "Numpy erlaubt einem sehr bequem bestimmte Elemente aus einem Array auszuwählen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.arange(0, 10)\n",
+    "\n",
+    "# like lists:\n",
+    "x[4]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# all elements with indices ≥1 and <4:\n",
+    "x[1:4]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# negative indices count from the end\n",
+    "x[-1], x[-2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# combination:\n",
+    "x[3:-2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# step size\n",
+    "x[::2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# trick for reversal: negative step\n",
+    "x[::-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y = np.array([x, x + 10, x + 20, x + 30])\n",
+    "y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# comma between indices\n",
+    "y[3, 2:-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# only one index ⇒ one-dimensional array\n",
+    "y[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# other axis: (: alone means the whole axis)\n",
+    "y[:, 3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# inspecting the number of elements per axis:\n",
+    "y.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ausgewählten Elementen kann man auch direkt einen Wert zuweisen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y[:, 3] = 0\n",
+    "y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Man kann Indexing sogar gleichzeitig auf der linken und rechten Seite benutzen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y[:,0] = x[3:7]\n",
+    "y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Transponieren des Arrays kehrt die Reihenfolge der Indizes um:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y.T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y.T.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Masken\n",
+    "Oft will man Elemente auswählen, die eine bestimmte Bedingung erfüllen.\n",
+    "\n",
+    "Hierzu erstellt man zuerst eine Maske (Arrays aus True/False-Werten).\n",
+    "\n",
+    "Diese kann man in eckigen Klammern übergeben."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = np.linspace(0, 2, 11)\n",
+    "b = a**2\n",
+    "\n",
+    "print(a >= 1)\n",
+    "\n",
+    "print(a[a >= 1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reduzieren von Arrays\n",
+    "\n",
+    "Viele Rechenoperationen reduzieren ein Array auf einen einzelnen Wert"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.sum(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.prod(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.mean(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Standardabweichung"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.std(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fehler des Mittelwerts (geht auch einfacher):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.std(x, ddof=1) / np.sqrt(len(x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Schätzer der Standardabweichung"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.std(x, ddof=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Differenzen zwischen benachbarten Elementen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z = x**2\n",
+    "np.diff(z)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Input / Output\n",
+    "\n",
+    "Einlesen aus Textdateien: `genfromtxt`\n",
+    "\n",
+    "Sie gibt den Inhalt einer Textdatei als Array zurück.\n",
+    "\n",
+    "Das Gegenstück ist `savetxt`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = np.arange(11)\n",
+    "x = np.linspace(0, 1, 11)\n",
+    "\n",
+    "np.savetxt('test.txt', [n, x])\n",
+    "\n",
+    "with open('test.txt', 'r') as f:\n",
+    "    print(f.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = np.array([n, x])\n",
+    "\n",
+    "np.savetxt('test.txt', np.column_stack([n, x]))\n",
+    "\n",
+    "with open('test.txt', 'r') as f:\n",
+    "    print(f.read())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Man sollte aber immer erklären, was man da abspeichert:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = np.arange(11)\n",
+    "x = np.linspace(0, 1, 11)\n",
+    "\n",
+    "# header schreibt eine Kommentarzeile in die erste Zeile der Datei\n",
+    "np.savetxt('test.txt', np.column_stack([n, x]), header=\"n x\")\n",
+    "with open('test.txt', 'r') as f:\n",
+    "    print(f.read())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Einlesen der Werte mit `genfromtxt` :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a, b = np.genfromtxt('test.txt', unpack=True)\n",
+    "a, b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SciPy\n",
+    "![SciPy](https://raw.githubusercontent.com/scipy/scipy-sphinx-theme/master/_static/scipyshiny_small.png)\n",
+    "\n",
+    "- Baut auf NumPy auf\n",
+    "- Kann numerisch integrieren, DGLs lösen, optimieren, minimieren, …\n",
+    "- Enthält auch physikalische Konstanten und wichtige mathematische Funktionen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# standard error of the mean\n",
+    "from scipy.stats import sem\n",
+    "sem(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# physical constants\n",
+    "import scipy.constants as const\n",
+    "const.epsilon_0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert temperatures:\n",
+    "print(const.C2K(100))\n",
+    "print(const.K2C(100))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert angles:\n",
+    "print(np.rad2deg(np.pi))\n",
+    "print(np.deg2rad(90))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# more constants (including units and errors)!\n",
+    "list(const.physical_constants.items())[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Achtung\n",
+    "Wenn solche Konstanten genutzt werden, muss das korrekt mitgeteilt, also zitiert werden.\n",
+    "Darauf gehen wir nächste Woche im LaTeX-Workshop ein :-)\n",
+    "\n",
+    "(Quelle hier: *python-scipy*)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const.physical_constants[\"proton mass\"]\n",
+    "# value, unit, error"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fitten\n",
+    "Oft möchte man eine Funktion, zum Beispiel eine Erwartung aus der Theorie, an die gemessenen Werte anpassen.\n",
+    "Dies nennt man Fit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fit arbitrary functions\n",
+    "from scipy.optimize import curve_fit\n",
+    "\n",
+    "x, y = np.genfromtxt('example_data.txt', unpack=True)\n",
+    "\n",
+    "def f(x, a, b):\n",
+    "    return a * x + b\n",
+    "\n",
+    "params, covariance_matrix = curve_fit(f, x, y)\n",
+    "\n",
+    "errors = np.sqrt(np.diag(covariance_matrix))\n",
+    "\n",
+    "print('a =', params[0], '±', errors[0])\n",
+    "print('b =', params[1], '±', errors[1])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# prepare plot\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.rcParams['figure.figsize'] = (10, 8)\n",
+    "plt.rcParams['font.size'] = 16\n",
+    "\n",
+    "\n",
+    "x_plot = np.linspace(0, 10)\n",
+    "\n",
+    "plt.plot(x, y, 'k.', label=\"example data\")\n",
+    "plt.plot(x_plot, f(x_plot, *params), 'r-', label='linearer Fit', linewidth=3)\n",
+    "plt.legend(loc=\"best\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "Da ein Fit mit `curve_fit()` intern ein Minimierungsalgorithmus ist, hängt   \n",
+    "das Ergebnis unter Umständen von den Anfangsbedingungen ab."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fit einer komplexeren Funktion: Sigmoidfunktion\n",
+    "(Ähnlich zum `tanh`)\n",
+    "\n",
+    "$$ f(x; a, b, c) = \\frac{a}{1 + \\exp(-(x-b))} + c$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sigmoid(x, a, b, c):\n",
+    "    y = a / (1 + np.exp(-(x-b))) + c\n",
+    "    return y\n",
+    "\n",
+    "x_plot = np.linspace(-50, 50, 1000)\n",
+    "\n",
+    "plt.xlabel('x')\n",
+    "plt.ylabel('y')\n",
+    "\n",
+    "plt.plot(x_plot, sigmoid(x_plot, 1, 0, 0), label=\"Sigmoid\")\n",
+    "plt.plot(x_plot, np.tanh(x_plot), label=\"tanh\")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Die Messwerte aus einem Praktikumsversuch:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x, y = np.loadtxt('fit_data_with_init_values.txt', unpack=True)\n",
+    "\n",
+    "plt.plot(x, y, 'ro', label=r'Messwerte')\n",
+    "\n",
+    "plt.xlabel('Temperatur / °C')\n",
+    "plt.ylabel('$GP$')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ein einfacher Fit wie oben funktioniert hier nicht so gut:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params, covariance_matrix = curve_fit(sigmoid, x, y)\n",
+    "\n",
+    "errors = np.sqrt(np.diag(covariance_matrix))\n",
+    "\n",
+    "print('a =', params[0], '±', errors[0])\n",
+    "print('b =', params[1], '±', errors[1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Schaut man sich die berechnete Ausgleichskurve an sieht man auch,   \n",
+    "dass das nicht stimmen kann:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.xlabel('Temperatur / °C')\n",
+    "plt.ylabel('$GP$')\n",
+    "\n",
+    "plt.plot(x, y, 'ro', label='Messdaten')\n",
+    "plt.plot(x_plot, sigmoid(x_plot, *params), \"b-\", label=r'Sigmoid Fit')\n",
+    "\n",
+    "plt.legend(loc='best')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Was macht man jetzt?**   \n",
+    "Bei solchen Fragen hilft die Dokumentation der Pythonmodule (hier: scipy) oder _Stackoverflow_ weiter.   \n",
+    "Folgendes _Google-Muster_ ist ein guter Anfang (beachte englische Sprache):  \n",
+    "\n",
+    "    python <module-name> <function-name> <What went wrong?>\n",
+    "\n",
+    "Also in diesem Fall: `python scipy curve_fit fails`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Damit dieser Fit funktioniert müssen die Startwerte für den internen   \n",
+    "Minimierungsalgorithmus angepasst werden.  \n",
+    "Aus der Dokumentation/Stackoverflow wissen wir jetzt, dass man mit dem   \n",
+    "_keyword argument_ `p0` (Standardwert is `p0=(1,1,1)`) die Startwerte einstellt:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params, covariance_matrix = curve_fit(sigmoid, x, y, p0=(-1, 40, 1))\n",
+    "\n",
+    "errors = np.sqrt(np.diag(covariance_matrix))\n",
+    "\n",
+    "print('a =', params[0], '±', errors[0])\n",
+    "print('b =', params[1], '±', errors[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.xlabel('Temperatur / °C')\n",
+    "plt.ylabel('$GP$')\n",
+    "\n",
+    "x_plot = np.linspace(0, 50, 1000)\n",
+    "\n",
+    "plt.plot(x, y, 'ro', label='Messwerte')\n",
+    "plt.plot(x_plot, sigmoid(x_plot, *params), \"b-\", label='Sigmoid Fit')\n",
+    "\n",
+    "plt.legend(loc='best')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Zum Vergleich der beiden Anfangswerte (seeds) kann man sich die einmal ansehen   \n",
+    "und mit den angepassten Parametern vergleichen:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "default_seed = (1,1,1)\n",
+    "good_seed = (-1,40,1)\n",
+    "\n",
+    "parameter = [default_seed, good_seed, params]\n",
+    "\n",
+    "x_plot = np.linspace(-80, 80, 1000)\n",
+    "\n",
+    "for p in parameter:\n",
+    "    plt.plot(x_plot, sigmoid(x_plot, *p),  label=\"f(x; {0:0.3f}, {1:0.3f}, {2:0.3f})\".format(*p))\n",
+    "    \n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Die richtigen Startwerte findet man entweder durch \n",
+    "\n",
+    "1. _trial and error_ => einfach ausprobieren bis es klappt\n",
+    "\n",
+    "2. _nachdenken_ => siehe unten\n",
+    "    \n",
+    "Im obigen Beispiel musste nur Parameter `b` angepasst werden,   \n",
+    "weil der für die Form der Kurve sehr wichtig ist.\n",
+    "\n",
+    "$$ f(x; a, b, c) = \\frac{a}{1 + \\exp(-(x-b))} + c$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "B = [0, 20, 40]\n",
+    "\n",
+    "x_plot = np.linspace(-50, 50, 1000)\n",
+    "\n",
+    "plt.xlabel('x')\n",
+    "plt.ylabel('y')\n",
+    "\n",
+    "\n",
+    "for b in B:\n",
+    "    \n",
+    "    line = plt.plot(x_plot, sigmoid(x_plot, 1, b, 0),  label=f\"f(x; 1, {b}, 0)\")\n",
+    "    plt.plot(b, sigmoid(b, 1, b, 0), \"o\", color=line[0].get_color(), ms=20, label=f\"f(x={b}) = {sigmoid(b, 1, b, 0)}\")\n",
+    "    \n",
+    "\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Der Parameter $b$ gibt den $x$-Wert an bei dem die Funktion auf die Hälfte des Maximums abgefallen ist.   \n",
+    "Bei den Messwerten oben ist die Stelle ungefähr bei $x=40$ also ist `b=40` ein guter Startwert."
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/python/scientific-python.ipynb
+++ b/python/scientific-python.ipynb
@@ -2,652 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "# ![Numpy](http://www.numpy.org/_static/numpy_logo.png)\n",
-    "\n",
-    "- Meist hat man nach in einer Auswertung Datenpunkte, die verarbeitet werden müssen\n",
-    "- Numpy ist eine Python-Bibliothek, die den Umgang mit Datenpunkten enorm vereinfacht"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import numpy as np"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "- Grunddatentyp von Numpy: das Array\n",
-    "- Kann man sich als effizientere Liste vorstellen\n",
-    "- Idee von Numpy: Man kann ein Array ähnlich wie eine Zahl verwenden. Operationen werden dann auf allen Elementen ausgeführt\n",
-    "- Am besten versteht man das mit einigen Beispielen:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "# convert list to array\n",
-    "x = np.array([1, 2, 3, 4, 5])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "2 * x"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x**2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x**x"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.cos(x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Achtung: Man braucht das `cos` aus numpy!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import math\n",
-    "math.cos(x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Selbstgeschriebene Funktionen, die nur für eine Zahl geschrieben wurden, funktionieren oft ohne Änderung mit Arrays!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def poly(y):\n",
-    "    return y + 2 * y**2 - y**3\n",
-    "\n",
-    "poly(x)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "poly(np.pi)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# this also works:\n",
-    "def poly(x):\n",
-    "    return x + 2 * x**2 - x**3\n",
-    "\n",
-    "poly(x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Das erlaubt es einem unter anderem sehr leicht physikalische Formeln auf seine Datenpunkte anzuwenden.\n",
-    "\n",
-    "Arrays können beliebige Dimension haben:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# two-dimensional array\n",
-    "y = np.array([[1, 2, 3],\n",
-    "              [4, 5, 6],\n",
-    "              [7, 8, 9]])\n",
-    "\n",
-    "y + y"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Das erlaubt es z.B. eine ganze Tabelle als ein Array abzuspeichern.\n",
-    "\n",
-    "Es gibt viele nützliche Funktionen, die bei der Erstellung von Arrays helfen:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.zeros(10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.ones((5, 2))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.linspace(0, 1, 11)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# like range() for arrays:\n",
-    "np.arange(0, 10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.logspace(-4, 5, 10)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Numpy Indexing\n",
-    "\n",
-    "Numpy erlaubt einem sehr bequem bestimmte Elemente aus einem Array auszuwählen"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = np.arange(0, 10)\n",
-    "\n",
-    "# like lists:\n",
-    "x[4]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# all elements with indices ≥1 and <4:\n",
-    "x[1:4]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# negative indices count from the end\n",
-    "x[-1], x[-2]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# combination:\n",
-    "x[3:-2]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# step size\n",
-    "x[::2]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# trick for reversal: negative step\n",
-    "x[::-1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y = np.array([x, x + 10, x + 20, x + 30])\n",
-    "y"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# comma between indices\n",
-    "y[3, 2:-1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# only one index ⇒ one-dimensional array\n",
-    "y[2]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# other axis: (: alone means the whole axis)\n",
-    "y[:, 3]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# inspecting the number of elements per axis:\n",
-    "y.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Ausgewählten Elementen kann man auch direkt einen Wert zuweisen"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y[:, 3] = 0\n",
-    "y"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Man kann Indexing sogar gleichzeitig auf der linken und rechten Seite benutzen"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y[:,0] = x[3:7]\n",
-    "y"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Transponieren des Arrays kehrt die Reihenfolge der Indizes um:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y.T"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y.T.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Masken\n",
-    "Oft will man Elemente auswählen, die eine bestimmte Bedingung erfüllen.\n",
-    "\n",
-    "Hierzu erstellt man zuerst eine Maske (Arrays aus True/False-Werten).\n",
-    "\n",
-    "Diese kann man in eckigen Klammern übergeben."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "a = np.linspace(0, 2, 11)\n",
-    "b = a**2\n",
-    "\n",
-    "print(a >= 1)\n",
-    "\n",
-    "print(a[a >= 1])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Reduzieren von Arrays\n",
-    "\n",
-    "Viele Rechenoperationen reduzieren ein Array auf einen einzelnen Wert"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.sum(x)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.prod(x)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.mean(x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Standardabweichung"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.std(x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Fehler des Mittelwerts (geht auch einfacher):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.std(x, ddof=1) / np.sqrt(len(x))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Schätzer der Standardabweichung"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.std(x, ddof=1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Differenzen zwischen benachbarten Elementen"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "z = x**2\n",
-    "np.diff(z)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Input / Output\n",
-    "\n",
-    "Einlesen aus Textdateien: `genfromtxt`\n",
-    "\n",
-    "Sie gibt den Inhalt einer Textdatei als Array zurück.\n",
-    "\n",
-    "Das Gegenstück ist `savetxt`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "n = np.arange(11)\n",
-    "x = np.linspace(0, 1, 11)\n",
-    "\n",
-    "np.savetxt('test.txt', [n, x])\n",
-    "\n",
-    "with open('test.txt', 'r') as f:\n",
-    "    print(f.read())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data = np.array([n, x])\n",
-    "\n",
-    "np.savetxt('test.txt', np.column_stack([n, x]))\n",
-    "\n",
-    "with open('test.txt', 'r') as f:\n",
-    "    print(f.read())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Man sollte aber immer erklären, was man da abspeichert:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "n = np.arange(11)\n",
-    "x = np.linspace(0, 1, 11)\n",
-    "\n",
-    "# header schreibt eine Kommentarzeile in die erste Zeile der Datei\n",
-    "np.savetxt('test.txt', np.column_stack([n, x]), header=\"n x\")\n",
-    "with open('test.txt', 'r') as f:\n",
-    "    print(f.read())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Einlesen der Werte mit `genfromtxt` :"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "a, b = np.genfromtxt('test.txt', unpack=True)\n",
-    "a, b"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# SciPy\n",
@@ -661,7 +15,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# standard error of the mean\n",
@@ -672,7 +28,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# physical constants\n",
@@ -683,7 +41,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# convert temperatures:\n",
@@ -694,7 +54,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# convert angles:\n",
@@ -705,7 +67,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# more constants (including units and errors)!\n",
@@ -726,7 +90,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "const.physical_constants[\"proton mass\"]\n",
@@ -745,7 +111,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# fit arbitrary functions\n",
@@ -767,7 +135,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# prepare plot\n",
@@ -807,7 +177,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def sigmoid(x, a, b, c):\n",
@@ -834,7 +206,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "x, y = np.loadtxt('fit_data_with_init_values.txt', unpack=True)\n",
@@ -855,7 +229,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "params, covariance_matrix = curve_fit(sigmoid, x, y)\n",
@@ -877,7 +253,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "plt.xlabel('Temperatur / °C')\n",
@@ -915,7 +293,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "params, covariance_matrix = curve_fit(sigmoid, x, y, p0=(-1, 40, 1))\n",
@@ -929,7 +309,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "plt.xlabel('Temperatur / °C')\n",
@@ -954,7 +336,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "default_seed = (1,1,1)\n",
@@ -989,7 +373,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "B = [0, 20, 40]\n",


### PR DESCRIPTION
Splitted the scientific-python notebook into scientific-python and numeric-python to separate the
numpy and scipy content.  Addresses #115.