### PR TITLE
gitignore im Python Ordner erweitert

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,4 +1,4 @@
 test.txt
 test_T.txt
-plot.pdf
 *.html
+*.pdf


### PR DESCRIPTION
Beim Durchlauf werden aus `matplotlib.ipynb` Z.374 & Z.380 noch Plots erzeugt, die nicht in der .gitignore erfasst wurden.

Deswegen Erweiterung von `plot.pdf` auf `*.pdf`, es sind nur die 3 pdf-Dateien im Ordner.