### PR TITLE
WIP: Embed ipynb images

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,16 @@ Folgende Themen sind Teil des Workshops:
 - up-to-date anaconda3 (using python 3.6.4)
 - poppler (for pdfseparate)
 - wget 
+- jupyter_contrib_nbextensions
 
 ## Installation
 
 For TeXLive and anaconda, follow the installtion instruction on
 http://toolbox.pep-dortmund.org/install
+
+### Jupyter-Notebook extension
+
+- `pip install jupyter_contrib_nbextensions`
 
 ### MacOS 
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -3,7 +3,7 @@ include ../common/common.mk
 all: $(patsubst %.ipynb, %.html, $(wildcard *.ipynb))
 
 %.html: %.ipynb
-	jupyter-nbconvert --execute --allow-errors --to html $<
+	jupyter-nbconvert --execute --allow-errors --to html_embed $<
 
 muon_plot.png: muon_plot.py muon_data.txt
 	python3 $<


### PR DESCRIPTION
This embeds local images in Jupyter Notebooks into the html files produced by `nbconvert`
using the exporter `html_embed`.
This exporter is be installed via `pip install jupyter_contrib_nbextensions`.

WIP: However, I am currently unsure about the formatting in the Readme.