### PR TITLE
Remove unexplained reference to rebase

### DIFF
--- a/git/content/git.tex
+++ b/git/content/git.tex
@@ -293,11 +293,6 @@
     git pull          & Commits herunterladen \\
     git push          & Commits hochladen
   \end{tabu}
-
-  \begin{itemize}
-    \item Aus der Installationsanleitung: \\
-      \texttt{git config --global pull.rebase true}
-  \end{itemize}
 \end{frame}
 
 \begin{frame}[fragile]{Achtung: Merge conflicts}


### PR DESCRIPTION
We might want to add a more thorough explanation of what rebase does,
but like this, it was just confusing.