### PR TITLE
Fixes to latex

### DIFF
--- a/common/packages.tex
+++ b/common/packages.tex
@@ -18,7 +18,6 @@
 
 \usefonttheme{professionalfonts}
 \usepackage[main=ngerman, english, french]{babel}
-\usepackage[german]{cleveref}
 
 \usepackage{fontspec}
 \setmainfont{Latin Modern Roman}[

--- a/common/packages.tex
+++ b/common/packages.tex
@@ -18,6 +18,7 @@
 
 \usefonttheme{professionalfonts}
 \usepackage[main=ngerman, english, french]{babel}
+\usepackage[german]{cleveref}
 
 \usepackage{fontspec}
 \setmainfont{Latin Modern Roman}[

--- a/latex/content/floats.tex
+++ b/latex/content/floats.tex
@@ -149,7 +149,7 @@
       In Abbildung~\ref{fig:logos} sehen Sie zwei Logos. \\[\baselineskip]
       In Abbildung~\ref{fig:pep2} sehen Sie das PeP-Logo. \\[\baselineskip]
       In Abbildung~\subref{fig:pep2} sehen Sie das PeP-Logo.\\[\baselineskip]
-      In Abbildung~\autoref{fig:pep2} sehen Sie das PeP-Logo.
+      In Abbildung~\ref{fig:pep2} sehen Sie das PeP-Logo.
   \end{CodeExample}
   \vspace{2em}
   \lstinline+\subref+ nur in \lstinline+\caption{…}+ zu Subfigures sinvoll.

--- a/latex/content/floats.tex
+++ b/latex/content/floats.tex
@@ -149,7 +149,7 @@
       In Abbildung~\ref{fig:logos} sehen Sie zwei Logos. \\[\baselineskip]
       In Abbildung~\ref{fig:pep2} sehen Sie das PeP-Logo. \\[\baselineskip]
       In Abbildung~\subref{fig:pep2} sehen Sie das PeP-Logo.\\[\baselineskip]
-      In Abbildung~\ref{fig:peplogo} sehen Sie das PeP-Logo.
+      In Abbildung~\ref{fig:pep2} sehen Sie das PeP-Logo.
   \end{CodeExample}
   \vspace{2em}
   \lstinline+\subref+ nur in \lstinline+\caption{…}+ zu Subfigures sinvoll.

--- a/latex/content/floats.tex
+++ b/latex/content/floats.tex
@@ -149,7 +149,7 @@
       In Abbildung~\ref{fig:logos} sehen Sie zwei Logos. \\[\baselineskip]
       In Abbildung~\ref{fig:pep2} sehen Sie das PeP-Logo. \\[\baselineskip]
       In Abbildung~\subref{fig:pep2} sehen Sie das PeP-Logo.\\[\baselineskip]
-      In Abbildung~\autoref{fig:pep2} sehen Sie das PeP-Logo.
+      In \autoref{fig:pep2} sehen Sie das PeP-Logo.
   \end{CodeExample}
   \vspace{2em}
   \lstinline+\subref+ nur in \lstinline+\caption{…}+ zu Subfigures sinvoll.

--- a/latex/content/floats.tex
+++ b/latex/content/floats.tex
@@ -142,14 +142,14 @@
       In Abbildung \ref{fig:logos} sehen Sie zwei Logos.
       In Abbildung \ref{fig:pep2} sehen Sie das PeP-Logo.
       In Abbildung \subref{fig:pep2} sehen Sie das PeP-Logo.
-      In \Cref{fig:pep2} sehen Sie das PeP-Logo.
+      In \autoref{fig:pep2} sehen Sie das PeP-Logo.
     \end{lstlisting}
     \CodeResult
       \strut
       In Abbildung~\ref{fig:logos} sehen Sie zwei Logos. \\[\baselineskip]
       In Abbildung~\ref{fig:pep2} sehen Sie das PeP-Logo. \\[\baselineskip]
       In Abbildung~\subref{fig:pep2} sehen Sie das PeP-Logo.\\[\baselineskip]
-      In \Cref{fig:pep2} sehen Sie das PeP-Logo.
+      In \autoref{fig:pep2} sehen Sie das PeP-Logo.
   \end{CodeExample}
   \vspace{2em}
   \lstinline+\subref+ nur in \lstinline+\caption{…}+ zu Subfigures sinvoll.

--- a/latex/content/floats.tex
+++ b/latex/content/floats.tex
@@ -142,14 +142,14 @@
       In Abbildung \ref{fig:logos} sehen Sie zwei Logos.
       In Abbildung \ref{fig:pep2} sehen Sie das PeP-Logo.
       In Abbildung \subref{fig:pep2} sehen Sie das PeP-Logo.
-      In \autoref{fig:pep2} sehen Sie das PeP-Logo.
+      In \Cref{fig:pep2} sehen Sie das PeP-Logo.
     \end{lstlisting}
     \CodeResult
       \strut
       In Abbildung~\ref{fig:logos} sehen Sie zwei Logos. \\[\baselineskip]
       In Abbildung~\ref{fig:pep2} sehen Sie das PeP-Logo. \\[\baselineskip]
       In Abbildung~\subref{fig:pep2} sehen Sie das PeP-Logo.\\[\baselineskip]
-      In \autoref{fig:pep2} sehen Sie das PeP-Logo.
+      In \Cref{fig:pep2} sehen Sie das PeP-Logo.
   \end{CodeExample}
   \vspace{2em}
   \lstinline+\subref+ nur in \lstinline+\caption{…}+ zu Subfigures sinvoll.

--- a/latex/content/floats.tex
+++ b/latex/content/floats.tex
@@ -149,7 +149,7 @@
       In Abbildung~\ref{fig:logos} sehen Sie zwei Logos. \\[\baselineskip]
       In Abbildung~\ref{fig:pep2} sehen Sie das PeP-Logo. \\[\baselineskip]
       In Abbildung~\subref{fig:pep2} sehen Sie das PeP-Logo.\\[\baselineskip]
-      In Abbildung~\ref{fig:pep2} sehen Sie das PeP-Logo.
+      In Abbildung~\autoref{fig:pep2} sehen Sie das PeP-Logo.
   \end{CodeExample}
   \vspace{2em}
   \lstinline+\subref+ nur in \lstinline+\caption{…}+ zu Subfigures sinvoll.

--- a/latex/content/floats.tex
+++ b/latex/content/floats.tex
@@ -149,7 +149,7 @@
       In Abbildung~\ref{fig:logos} sehen Sie zwei Logos. \\[\baselineskip]
       In Abbildung~\ref{fig:pep2} sehen Sie das PeP-Logo. \\[\baselineskip]
       In Abbildung~\subref{fig:pep2} sehen Sie das PeP-Logo.\\[\baselineskip]
-      In \autoref{fig:pep2} sehen Sie das PeP-Logo.
+      In Abbildung~\autoref{fig:pep2} sehen Sie das PeP-Logo.
   \end{CodeExample}
   \vspace{2em}
   \lstinline+\subref+ nur in \lstinline+\caption{…}+ zu Subfigures sinvoll.

--- a/latex/content/math-env.tex
+++ b/latex/content/math-env.tex
@@ -10,6 +10,7 @@
       \item Alle Gleichungen werden automatisch nummeriert
       \item \texttt{*} nach dem Umgebungsnamen sorgt für unnumerierte Gleichung
       \item Unnumerierte Gleichungen sollten selten sein
+      \item Achtung: Leere Zeilen führen in allen Mathe-Umgebungen zu einem Fehler
   \end{itemize}
 \end{frame}
 


### PR DESCRIPTION
fixes #165 and #166 
but reveals an other issue: `\autoref` does not seem to work properly, it does not insert the description for the referenced object.

`In \autoref{fig:pep2} sehen Sie das PeP-Logo.` 
results in 
`In 2a sehen Sie das PeP-Logo.` 
in contrast to
`In Abbildung 2a sehen Sie das PeP-Logo.` 

I found this [stack-exchange](https://tex.stackexchange.com/questions/256672/autoref-does-not-seem-to-be-working-properly) and other sources saying, that it is necessary to set the descriptions
beforehand (e.g. for a figure `\addto\extrasngerman{\def\figureautorefname{Abbildung}}`).

In the hyperref docs is this example:
```latex
%Example for a redefinition if babel is used:
\usepackage[ngerman]{babel}
\addto\extrasngerman{%
     \def\subsectionautorefname{Unterkapitel}%
}
```
I am not sure if means that this renaming is necessary :thinking: 
An alternative would be the use of `cleverref`.

After some tinkering:
1. `\autoref` does not seem to work at all, even if you define the names for the reference-objects 
    manually (as shown above), the label contains only the reference number and no text label
2. `cleveref` does insert the right label, but I cant figure out how to use multiple languages ...
     come to think of it, the reference labels should not change language anyway :man_facepalming:
     Defining the language in the header once works at least for german and english.

I would prefer to use `cleveref` for this but we could also leave this out entirely, any opinions?












