### PR TITLE
fixed path to muon plot on teaser slides

### DIFF
--- a/teaser-slides/teaser-slides.tex
+++ b/teaser-slides/teaser-slides.tex
@@ -49,7 +49,7 @@
 \end{frame}
 
 \begin{frame}[plain]
-  \includegraphics[width=\textwidth]{../python/muon_plot.png}
+  \includegraphics[width=\textwidth]{../python/build/muon_plot.png}
 \end{frame}
 
 \begin{frame}


### PR DESCRIPTION
Just one remaining error from the latest cleaning up of the python directory