### PR TITLE
changed the parts from issue#216

### DIFF
--- a/latex/content/bibliography.tex
+++ b/latex/content/bibliography.tex
@@ -54,7 +54,7 @@
 \end{frame}
 
 \begin{frame}[fragile]{\texttt{.bib}-Dateien (III)}
-  \lstinputlisting[firstline=20, lastline=32]{examples.bib}
+  \lstinputlisting[firstline=20, lastline=30]{examples.bib}
   \vspace{1em}
   \fullcite{root}
 \end{frame}
@@ -70,7 +70,6 @@
   \vspace{1em}
   \fullcite{hastie}
 \end{frame}
-
 
 \begin{frame}[fragile]{\texttt{.bib}-Dateien (VI)}
   \lstinputlisting[firstline=50, lastline=53]{examples.bib}

--- a/latex/content/tables.tex
+++ b/latex/content/tables.tex
@@ -149,8 +149,8 @@
         \begin{tabular}{S[table-format=3.1] S S S S}
           \toprule
           & \multicolumn{2}{c}{Technetium} & \multicolumn{2}{c}{Molybdän} \\
-          \cmidrule(lr){2-3}\cmidrule(lr){4-5} 
-          {$\lambda \:/\: \si{\nano\meter}$}
+          \cmidrule(lr){2-3}\cmidrule(lr){4-5}
+          {$\lambda \mathbin{/} \si{\nano\meter}$}
           & {$\phi_1$} & {$\phi_2$} & {$\phi_1$} & {$\phi_2$} \\
           \midrule
           663.0 & 12.1 & 14.4 & 13.1 & 16.9 \\
@@ -173,8 +173,8 @@
       \begin{tabular}{S[table-format=3.1] S S S S}
         \toprule
         & \multicolumn{2}{c}{Technetium} & \multicolumn{2}{c}{Molybdän} \\
-        \cmidrule(lr){2-3}\cmidrule(lr){4-5} 
-        {$\lambda \:/\: \si{\nano\meter}$}
+        \cmidrule(lr){2-3}\cmidrule(lr){4-5}
+        {$\lambda \mathbin{/} \si{\nano\meter}$}
         & {$\phi_1$} & {$\phi_2$} & {$\phi_1$} & {$\phi_2$} \\
         \midrule
         663.0 & 12.1 & 14.4 & 13.1 & 16.9 \\
@@ -200,7 +200,7 @@
         S[table-format=2.1]
       }
         \toprule
-        \multicolumn{2}{c}{$x \:/\: \si{\ohm}$} \\
+        \multicolumn{2}{c}{$x \mathbin{/} \si{\ohm}$} \\
         \midrule
         663.0 & 12.1 \\
         670.0 & 10.9 \\
@@ -217,7 +217,7 @@
         S[table-format=2.1]
       }
         \toprule
-        \multicolumn{2}{c}{$x \:/\: \si{\ohm}$} \\
+        \multicolumn{2}{c}{$x \mathbin{/} \si{\ohm}$} \\
         \midrule
         663.0 & 12.1 \\
         670.0 & 10.9 \\


### PR DESCRIPTION
implementation of #216
- changed the `\:/\:` bits to `\mathbin{/}`
- lines for `\cite{root}` were to long, `@online{wingate` was included on the slide  