### PR TITLE
.bib example III - no overlap with example IV

### DIFF
--- a/latex/content/bibliography.tex
+++ b/latex/content/bibliography.tex
@@ -54,7 +54,7 @@
 \end{frame}
 
 \begin{frame}[fragile]{\texttt{.bib}-Dateien (III)}
-  \lstinputlisting[firstline=20, lastline=32]{examples.bib}
+  \lstinputlisting[firstline=20, lastline=30]{examples.bib}
   \vspace{1em}
   \fullcite{root}
 \end{frame}


### PR DESCRIPTION
on slide 109 the beginning of slide 110 (@online{wingate,) appeared.
fixed by: example snippet shortened by 2 lines.