### PR TITLE
Update git readme with  Fira Code guide

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -1,3 +1,8 @@
 # Git
 
 In diesem Kurs werden Grundlagen der Versionskontrolle mit Git vermittelt.
+
+## Build dependencies
+
+Um die Präsentation zu kompilieren wird die Schriftart [FiraCode](https://github.com/tonsky/FiraCode) benötigt.
+Bei den meisten Distributionen gibt es das Package im repository, es gibt eine [Installationsanleitung](https://github.com/tonsky/FiraCode/wiki/Linux-instructions#installing-with-a-package-manager), die auch die Packagename im Repository auflistet.


### PR DESCRIPTION
There has been some trouble with compiling the tex document because Firacode is not in the main repo in apt. This notice should help.