### PR TITLE
Fix flake8 warnings/errors. Format with black.

### DIFF
--- a/exercises-toolbox/5-uncertainties/2-linregress/aufgabe.txt
+++ b/exercises-toolbox/5-uncertainties/2-linregress/aufgabe.txt
@@ -1,4 +1,4 @@
-Schreibe einen Wrapper für linregress (siehe 2-numpy/4-linregress), der die Ausgabe durch Verwendung von uncertainties vereinfacht.
+Schreibe einen Wrapper für linregress (siehe 4-scipy/2-linregress), der die Ausgabe durch Verwendung von uncertainties vereinfacht.
 
 Dabei sollte ein Array aus A und B zurückgegeben werden, wobei A und B ufloats sind.
 

--- a/exercises-toolbox/5-uncertainties/4-linleastsquares/linleastsquares.tex
+++ b/exercises-toolbox/5-uncertainties/4-linleastsquares/linleastsquares.tex
@@ -33,7 +33,7 @@ minimal ist, der Funktionsgraph also minimal von den Datenpunkten abweicht.
 \subsection*{Bestimmung der Parameter}
 
 \begin{enumerate}
-  \item Zuerst wird die sogennante Designmatrix $\symbf{A}$ aufgestellt.
+  \item Zuerst wird die sogenannte Designmatrix $\symbf{A}$ aufgestellt.
     Sie enthält die Funktionswerte für jede Funktion $f_i$ ausgewertet an den gemessenen $x_j$:
     \begin{equation}
       \symbf{A} =

--- a/python/uncertainties.ipynb
+++ b/python/uncertainties.ipynb
@@ -67,7 +67,7 @@
     "y = ufloat(3, 1)\n",
     "\n",
     "print(x - y)\n",
-    "print(x - x) # error is zero!\n",
+    "print(x - x)  # error is zero!\n",
     "\n",
     "print(x == y)"
    ]
@@ -161,8 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from uncertainties.unumpy import (nominal_values as noms,\n",
-    "                                  std_devs as stds)\n",
+    "from uncertainties.unumpy import nominal_values as noms, std_devs as stds\n",
     "\n",
     "print(noms(x))\n",
     "print(stds(x))"
@@ -185,15 +184,16 @@
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "plt.rcParams['figure.figsize'] = (8, 4)\n",
-    "plt.rcParams['font.size'] = 16\n",
+    "\n",
+    "plt.rcParams[\"figure.figsize\"] = (8, 4)\n",
+    "plt.rcParams[\"font.size\"] = 16\n",
     "\n",
     "x = np.array([90, 60, 45, 100, 15, 23, 52, 30, 71, 88])\n",
     "y = np.array([90, 71, 65, 100, 45, 60, 75, 85, 100, 80])\n",
     "\n",
-    "plt.plot(x, y, 'ro')\n",
-    "plt.xlabel('x')\n",
-    "plt.ylabel('y')\n",
+    "plt.plot(x, y, \"ro\")\n",
+    "plt.xlabel(\"x\")\n",
+    "plt.ylabel(\"y\")\n",
     "plt.show()"
    ]
   },
@@ -218,7 +218,7 @@
     "\n",
     "dx = x - x_mean\n",
     "dy = y - y_mean\n",
-    "corr_coeff = np.sum(dx * dy) / np.sqrt(np.sum(dx**2) * np.sum(dy**2))\n",
+    "corr_coeff = np.sum(dx * dy) / np.sqrt(np.sum(dx ** 2) * np.sum(dy ** 2))\n",
     "print(corr_coeff)"
    ]
   },
@@ -239,10 +239,9 @@
     "\n",
     "values = [1, 2]\n",
     "\n",
-    "cov = [[0.5, 0.25],\n",
-    "       [0.25, 0.2]]\n",
+    "cov = [[0.5, 0.25], [0.25, 0.2]]\n",
     "\n",
-    "x, y = correlated_values(values, cov) "
+    "x, y = correlated_values(values, cov)"
    ]
   },
   {
@@ -263,19 +262,21 @@
    "source": [
     "%matplotlib inline\n",
     "\n",
-    "from numpy.random import normal\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "plt.rcParams['figure.figsize'] = (10, 8)\n",
-    "plt.rcParams['font.size'] = 16\n",
+    "\n",
+    "plt.rcParams[\"figure.figsize\"] = (10, 8)\n",
+    "plt.rcParams[\"font.size\"] = 16\n",
     "from scipy.optimize import curve_fit\n",
     "from uncertainties import correlated_values, correlation_matrix\n",
     "\n",
+    "\n",
     "def f1(x, a, phi):\n",
-    "    return a * np.cos(x + phi) \n",
+    "    return a * np.cos(x + phi)\n",
+    "\n",
     "\n",
     "def f2(x, a, b):\n",
-    "    return a * np.cos(x) + b * np.sin(x) \n",
+    "    return a * np.cos(x) + b * np.sin(x)\n",
     "\n",
     "\n",
     "x = np.linspace(0, 4 * np.pi, 15)\n",
@@ -290,10 +291,10 @@
     "\n",
     "x_plot = np.linspace(0, 4 * np.pi, 1000)\n",
     "\n",
-    "plt.plot(x, y, 'k.')\n",
+    "plt.plot(x, y, \"k.\")\n",
     "\n",
-    "plt.plot(x_plot, f1(x_plot, *noms(params1)), label='f1', lw=2)\n",
-    "plt.plot(x_plot, f2(x_plot, *noms(params2)), '--', label='f2', lw=2)\n",
+    "plt.plot(x_plot, f1(x_plot, *noms(params1)), label=\"f1\", lw=2)\n",
+    "plt.plot(x_plot, f2(x_plot, *noms(params2)), \"--\", label=\"f2\", lw=2)\n",
     "\n",
     "plt.legend()\n",
     "\n",
@@ -302,8 +303,8 @@
     "print(correlation_matrix(params1))\n",
     "print(correlation_matrix(params2))\n",
     "\n",
-    "mat1 = ax1.matshow(correlation_matrix(params1), cmap='RdBu_r', vmin=-1, vmax=1)\n",
-    "mat2 = ax2.matshow(correlation_matrix(params2), cmap='RdBu_r', vmin=-1, vmax=1)\n",
+    "mat1 = ax1.matshow(correlation_matrix(params1), cmap=\"RdBu_r\", vmin=-1, vmax=1)\n",
+    "mat2 = ax2.matshow(correlation_matrix(params2), cmap=\"RdBu_r\", vmin=-1, vmax=1)\n",
     "fig.colorbar(mat1, ax=ax1)\n",
     "fig.colorbar(mat2, ax=ax2)"
    ]
@@ -326,8 +327,8 @@
     "x = np.linspace(0, 10)\n",
     "y = unp.uarray(np.linspace(0, 5), 1)\n",
     "\n",
-    "#plt.plot(x, y, 'rx')\n",
-    "plt.errorbar(x, unp.nominal_values(y), yerr=unp.std_devs(y), fmt='rx')"
+    "# plt.plot(x, y, 'rx')\n",
+    "plt.errorbar(x, unp.nominal_values(y), yerr=unp.std_devs(y), fmt=\"rx\")"
    ]
   },
   {
@@ -370,7 +371,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x, y, z = sympy.var('x y z')\n",
+    "x, y, z = sympy.var(\"x y z\")\n",
     "\n",
     "x + y + z"
    ]
@@ -388,8 +389,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f = x + y**3 - sympy.cos(z)**2\n",
+    "f = x + y ** 3 - sympy.cos(z) ** 2\n",
     "\n",
+    "print(f)\n",
     "print(f.diff(x))\n",
     "print(f.diff(y))\n",
     "print(f.diff(z))\n",
@@ -411,24 +413,27 @@
    "source": [
     "import sympy\n",
     "\n",
+    "\n",
     "def error(f, err_vars=None):\n",
     "    from sympy import Symbol, latex\n",
+    "\n",
     "    s = 0\n",
     "    latex_names = dict()\n",
-    "    \n",
-    "    if err_vars == None:\n",
+    "\n",
+    "    if err_vars is None:\n",
     "        err_vars = f.free_symbols\n",
-    "        \n",
+    "\n",
     "    for v in err_vars:\n",
-    "        err = Symbol('latex_std_' + v.name)\n",
-    "        s += f.diff(v)**2 * err**2\n",
-    "        latex_names[err] = '\\\\sigma_{' + latex(v) + '}'\n",
-    "        \n",
+    "        err = Symbol(\"latex_std_\" + v.name)\n",
+    "        s += f.diff(v) ** 2 * err ** 2\n",
+    "        latex_names[err] = \"\\\\sigma_{\" + latex(v) + \"}\"\n",
+    "\n",
     "    return latex(sympy.sqrt(s), symbol_names=latex_names)\n",
     "\n",
-    "E, q, r = sympy.var('E_x q r')\n",
     "\n",
-    "f = E + q**2 * r\n",
+    "E, q, r = sympy.var(\"E_x q r\")\n",
+    "\n",
+    "f = E + q ** 2 * r\n",
     "\n",
     "print(f)\n",
     "print(error(f))\n",
@@ -446,7 +451,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -460,7 +465,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The steps below were done because I found a `if var == None`:

The warnings/errors were reported by `nbqa flake8
python/uncertainties.ipynb --extend-ignore=E402`, which ignores 'module level import not at top of file'.

Formatted via `nbqa black python/uncertainties.ipynb`.