### PR TITLE
Fix Formelsatz Slides

### DIFF
--- a/common/header.tex
+++ b/common/header.tex
@@ -3,5 +3,5 @@
 \input{commands.tex}
 
 \author{PeP et al.\ Toolbox Workshop}
-\date{2020}
+\date{2021}
 \institute[Pep et al.\ e.V.]{\includegraphics[width=0.4\textwidth]{logos/pep.pdf}}

--- a/latex/content/floats.tex
+++ b/latex/content/floats.tex
@@ -137,7 +137,7 @@
   \end{itemize}
 \end{frame}
 
-\begin{frame}[fragile]{\lstinline+\\ref+ vs. \lstinline+\\subref+}
+\begin{frame}[fragile]{\texttt{\backslash ref} vs. \texttt{\backslash subref}}
   \begin{CodeExample}{0.47}
     \begin{lstlisting}
       In Abbildung \ref{fig:logos} sehen Sie zwei Logos.

--- a/latex/content/math-advanced.tex
+++ b/latex/content/math-advanced.tex
@@ -193,7 +193,7 @@
   \end{CodeExample}
 \end{frame}
 
-\begin{frame}[fragile]{\lstinline+\\intertext+}
+\begin{frame}[fragile]{Textausrichtung in \texttt{align}-Umgebung}
   \lstinline+\intertext+ erhält die Ausrichtung der \lstinline+align+-Umgebung.
   \begin{CodeExample}{0.60}
     \begin{lstlisting}
@@ -220,7 +220,7 @@
   \end{CodeExample}
 \end{frame}
 
-\begin{frame}[fragile]{\lstinline+\\underbrace+}
+\begin{frame}[fragile]{Ergänzende Erklärungen für Formeln}
   \begin{CodeExample}{0.65}
     \begin{lstlisting}
       f(x)=
@@ -239,7 +239,7 @@
   \end{CodeExample}
 \end{frame}
 
-\begin{frame}[fragile]{\lstinline+\\phantom+}
+\begin{frame}[fragile]{Ausrichtung trotz fehlender Symbole mit \texttt{\backslash phantom}}
   \begin{CodeExample}{0.60}
     \begin{lstlisting}
       \begin{align*}
@@ -286,7 +286,7 @@
   \lstinline+\hphantom+ wirkt nur horizontal und hat keine Höhe. \\
 \end{frame}
 
-\begin{frame}[fragile]{\lstinline+\\vphantom+}
+\begin{frame}[fragile]{Ausrichtung vertikaler Umbrüche mit \texttt{\backslash vphantom}}
   \begin{CodeExample}{0.8}
     \begin{lstlisting}
       \begin{align*}

--- a/latex/content/siunitx.tex
+++ b/latex/content/siunitx.tex
@@ -62,7 +62,7 @@
   \end{Packages}
 \end{frame}
 
-\begin{frame}[fragile]{\texttt{siunitx}: Zahlen mit \lstinline+\\num+}
+\begin{frame}[fragile]{\texttt{siunitx}: Zahlen mit \texttt{\backslash num}}
   \begin{CodeExample}{0.7}[Zahlen mit automatischen 3er-Gruppen]
     \begin{lstlisting}
       \num{1.23456}
@@ -99,7 +99,7 @@
   \end{CodeExample}
 \end{frame}
 
-\begin{frame}[fragile]{\texttt{siunitx}: Einheiten mit \lstinline+\\unit+}
+\begin{frame}[fragile]{\texttt{siunitx}: Einheiten mit \texttt{\backslash unit}}
   \begin{CodeExample}{0.8}[Einheiten]
     \begin{lstlisting}
       \unit{\meter\per\second}
@@ -146,7 +146,7 @@
   \end{CodeExample}
 \end{frame}
 
-\begin{frame}[fragile]{\texttt{siunitx}: Physikalische Größe, eine Zahl mit Einheit: \lstinline+\\qty+}
+\begin{frame}[fragile]{\texttt{siunitx}: Physikalische Größe, eine Zahl mit Einheit: \texttt{\backslash qty}}
   \begin{CodeExample}{0.72}[\lstinline+\\qty+ {=} Kombination aus \lstinline+\\num+ und \lstinline+\\unit+]
     \begin{lstlisting}
       \qty{5}{\percent}

--- a/latex/content/siunitx.tex
+++ b/latex/content/siunitx.tex
@@ -58,8 +58,6 @@
         % per-mode=reciprocal,      % m s^{-1}
         % output-decimal-marker=.,         % . statt , für Dezimalzahlen
       ]{siunitx}
-      % Fix missing micro sign with TL2017
-      \sisetup{math-micro=\text{µ},text-micro=µ}
     \end{lstlisting}
   \end{Packages}
 \end{frame}

--- a/poster/poster.tex
+++ b/poster/poster.tex
@@ -16,7 +16,7 @@
     \includegraphics[width=\textwidth]{logos/pep.pdf}%
   \end{minipage}%
   \begin{minipage}{0.75\textwidth}%
-    \centering\fontsize{50}{60}\bfseries\selectfont Toolbox-Workshop 2020%
+    \centering\fontsize{50}{60}\bfseries\selectfont Toolbox-Workshop 2021%
   \end{minipage}%
 
   \vspace{0.5cm}
@@ -30,17 +30,16 @@
 
   \begin{center}
     \huge \textbf{Praktikums-Versuche richtig auswerten!} \\[0.5\baselineskip]
-    12.–16.~Oktober 2020, tba~Uhr, Zoom
+    27.~September~–~01.~Oktober 2021, 13\,-\,17~Uhr, tba
   \end{center}
   \vspace{0.5cm}
   \begin{center}
     \huge \textbf{Wissenschaftliche Arbeiten verfassen mit} \textrm{\LaTeX}\\[0.5\baselineskip]
-    19.–23.~Oktober~2020, tba~Uhr, Zoom
-    % \textcolor{red!80!black}{Am 1.10. in Chemie HS01}
+    04.~–~08.~Oktober~2021, 13\,-\,17~Uhr, tba
   \end{center}
   \vspace{0.5cm}
   \begin{center}
-    \large Software installieren und Anmelden: \\
+    \large Software installieren und \textbf{Anmelden}: \\
     \Huge \href{https://toolbox.pep-dortmund.org}{toolbox.pep-dortmund.org}
   \end{center}
 

--- a/teaser-slides/teaser-slides.tex
+++ b/teaser-slides/teaser-slides.tex
@@ -1,8 +1,8 @@
 \input{header.tex}
 
-\title[Toolbox 2020]{Toolbox-Workshop 2020}
+\title[Toolbox 2021]{Toolbox-Workshop 2021}
 \subtitle{Python, Unix, Make, Git, \LaTeX{}}
-\date{12.~Oktober – 23.~Oktober 2020}
+\date{27.~September – 08.~Oktober 2021}
 \institute[Pep et al.\ e.V.]{\includegraphics[height=2cm]{logos/pep.pdf}}
 \author[Toolbox-Team]{}
 
@@ -26,7 +26,7 @@
   \vspace{2cm}
   \begin{center}
     \huge Praktikums-Versuche richtig auswerten!\\
-    12. – 16.~Oktober 2020, tba~Uhr, Zoom 
+    27.~September – 01.~Oktober 2021, 13 - 17~Uhr, Ort: tba
   \end{center}
   \begin{tikzpicture}[remember picture, overlay]
     \tikzset{shift={(current page.center)}}
@@ -56,7 +56,7 @@
   \begin{center}
     \huge Wissenschaftliche Arbeiten verfassen mit \\[0.5\baselineskip]
     \textrm{\fontsize{80}{120}\selectfont\LaTeX{}}\\[0.5\baselineskip]
-    19. – 23.~Oktober 2019, tba~Uhr, Zoom\\
+    04. – 08.~Oktober 2019, 13 - 17~Uhr, Ort: tba
     %\textcolor{red!70!black}{Am 1.~Oktober in Chemie HS01}
   \end{center}
 \end{frame}
@@ -76,9 +76,9 @@
   \huge
   Falls es Probleme bei der Installation gibt oder ihr Linux installieren wollt:\\[0.5\baselineskip]
   \begin{enumerate}
-    \item Mail an \href{mailto:toolbox-pep-dortmund@googlegroups.com}{toolbox-pep-dortmund@googlegroups.com}
+    \item Mail an \href{mailto:Pep-toolbox.physik@lists.tu-dortmund.de}{Pep-toolbox.physik@lists.tu-dortmund.de}
     %\item Im Büro vorbeikommen (CP-03-156/CP-01-178)
-    \item Donnerstag 8.10.2020: ab 9:00 betreutes Installieren in Zoom %CP-03-150
+    \item Donnerstag 23.09.2020: ab 9:00 betreutes Installieren, Ort: tba
   \end{enumerate}
 \end{frame}
 \begin{frame}

--- a/teaser-slides/teaser-slides.tex
+++ b/teaser-slides/teaser-slides.tex
@@ -76,7 +76,7 @@
   \huge
   Falls es Probleme bei der Installation gibt oder ihr Linux installieren wollt:\\[0.5\baselineskip]
   \begin{enumerate}
-    \item Mail an \href{mailto:Pep-toolbox.physik@lists.tu-dortmund.de}{Pep-toolbox.physik@lists.tu-dortmund.de}
+    \item Mail an \href{mailto:pep-toolbox.physik@lists.tu-dortmund.de}{pep-toolbox.physik@lists.tu-dortmund.de}
     %\item Im Büro vorbeikommen (CP-03-156/CP-01-178)
     \item Donnerstag 23.09.2020: ab 9:00 betreutes Installieren, Ort: tba
   \end{enumerate}

--- a/teaser-slides/teaser-slides.tex
+++ b/teaser-slides/teaser-slides.tex
@@ -56,7 +56,7 @@
   \begin{center}
     \huge Wissenschaftliche Arbeiten verfassen mit \\[0.5\baselineskip]
     \textrm{\fontsize{80}{120}\selectfont\LaTeX{}}\\[0.5\baselineskip]
-    04. – 08.~Oktober 2019, 13 - 17~Uhr, Ort: tba
+    04. – 08.~Oktober 2021, 13 - 17~Uhr, Ort: tba
     %\textcolor{red!70!black}{Am 1.~Oktober in Chemie HS01}
   \end{center}
 \end{frame}
@@ -78,7 +78,7 @@
   \begin{enumerate}
     \item Mail an \href{mailto:pep-toolbox.physik@lists.tu-dortmund.de}{pep-toolbox.physik@lists.tu-dortmund.de}
     %\item Im Büro vorbeikommen (CP-03-156/CP-01-178)
-    \item Donnerstag 23.09.2020: ab 9:00 betreutes Installieren, Ort: tba
+    \item Donnerstag 23.09.2021: ab 9:00 betreutes Installieren, Ort: tba
   \end{enumerate}
 \end{frame}
 \begin{frame}


### PR DESCRIPTION
Hi,

I deleted `\sisetup{math-micro=\text{µ},text-micro=µ}`. There comes a warning that this option is no longer needed.
Quote:
`Package siunitx Warning: Option "math-micro" has been removed in this release.`

I have a couple of questions.
- [x] The font color in the Formelsatz slides is horrible. This dark red on top of the dark grey. Has anyone a suggestion for a better color or should I just use texttt instead of the `\lstinline+\\intertext+`?

- [x] Why do we have the dollar signs in the chemical slides around every command but not in the math slides where these are needed to?