### PR TITLE
Recommend `zdiff3` instead of `diff3` as `merge.conflictstyle`

### DIFF
--- a/git/content/git.tex
+++ b/git/content/git.tex
@@ -330,7 +330,7 @@
         \item Vorgeschlagene Nachricht kann angenommen werden (In vim \texttt{":wq"} eintippen)
       \end{enumerate}
   \end{enumerate}
-  Nützlich: \texttt{git config --global merge.conflictstyle diff3}
+  Nützlich: \texttt{git config --global merge.conflictstyle zdiff3}
 \end{frame}
 
 \begin{frame}{Zu früheren Versionen zurückkehren}


### PR DESCRIPTION
Quoting from [The GitHub Blog](https://github.blog/2022-01-24-highlights-from-git-2-35/#:~:text=a%20new%20mode%2C%20%E2%80%9C-,zdiff3,-%E2%80%9D%2C%20which%20zealously%20moves):

> The default value for this configuration is “merge”, which produces the merge conflict markers that you are likely familiar with. But there is a different mode, “diff3”, which shows the merge base in addition to the changes on either side.
> **Git 2.35** introduces a new mode, “zdiff3”, which zealously moves any lines in common at the beginning or end of a conflict outside of the conflicted area, which makes the conflict you have to resolve a little bit smaller.

The blog also includes a simple example.
