### PR TITLE
fixed not missing variable name in error example

### DIFF
--- a/python/python.ipynb
+++ b/python/python.ipynb
@@ -1714,6 +1714,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "del n # Please ignore me, I'm just setting the stage for the example\n",
     "a = 5\n",
     "b = 7\n",
     "c = 9\n",
@@ -1972,7 +1973,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1986,7 +1987,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
added `del n` to force `n` to be undefined.