### PR TITLE
Add pdfcol package (formerly included in oberdiek)

### DIFF
--- a/tex-packages.txt
+++ b/tex-packages.txt
@@ -68,3 +68,4 @@ upquote
 lineno
 catchfile
 framed
+pdfcol


### PR DESCRIPTION
To find out in what package a missing file is, you can use:
```
$ tlmgr search --file --global pdfcol.sty
tlmgr: package repository https://ctan.mirror.norbert-ruehl.de/systems/texlive/tlnet (verified)
lwarp:
	texmf-dist/tex/latex/lwarp/lwarp-pdfcol.sty
pdfcol:
	texmf-dist/tex/latex/pdfcol/pdfcol.sty
```