### PR TITLE
fixed order of variables

### DIFF
--- a/python/uncertainties.ipynb
+++ b/python/uncertainties.ipynb
@@ -177,9 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -256,9 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -326,15 +322,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x = np.linspace(0, 10)\n",
     "y = unp.uarray(np.linspace(0, 5), 1)\n",
     "\n",
-    "ax, fig = plt.subplots(1, 1, layout=\"constrained\")\n",
+    "fig, ax = plt.subplots(1, 1, layout=\"constrained\")\n",
     "\n",
     "# ax.plot(x, y, 'rx')\n",
     "ax.errorbar(x, unp.nominal_values(y), yerr=unp.std_devs(y), fmt=\"rx\");"
@@ -478,5 +472,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Cell 12 in uncertainties.ipynb threw error. The variables fig and ax had the wrong order, this resulted in the error.
Now the notebook executes without errors.