### PR TITLE
Fix -B flag in make.tex

### DIFF
--- a/make/content/make.tex
+++ b/make/content/make.tex
@@ -148,7 +148,7 @@
   \begin{tabu}{>{\ttfamily}l X[,L]}
     make \textit{target} & statt des ersten in der \texttt{Makefile} genannten Targets (meist \texttt{all}) nur \texttt{target} erstellen \\
     make -n              & dry run: Befehle anzeigen aber nicht ausführen \\
-    make -b              & Force: ausführen aller Schritte, ignorieren des Alters aller Dateien \\
+    make -B              & Force: ausführen aller Schritte, ignorieren des Alters aller Dateien \\
     make -p              & Datenbank aller Abhängigkeiten ausgeben
   \end{tabu}
   \begin{itemize}


### PR DESCRIPTION
Change `-b` to `-B` to unconditionally make all targets. `-b` is ignored for compatibility.