### PR TITLE
Add correct link to numpy citation

### DIFF
--- a/latex/content/bibliography.tex
+++ b/latex/content/bibliography.tex
@@ -172,7 +172,7 @@
   Viele Programmbibliotheken haben auch wissenschaftliche Veröffentlichungen,
   die zusätzlich zitiert werden sollten:
 
-  Zum Beispiel: \url{https://www.scipy.org/citing.html}
+  Zum Beispiel: \url{https://numpy.org/citing-numpy/}
 
   \begin{block}{Beispiel}
     \footnotesize


### PR DESCRIPTION
Link points to scipy citation, not numpy. This PR fixes that and provides the correct link to numpy.