### PR TITLE
Make expert change

### DIFF
--- a/make/content/advanced.tex
+++ b/make/content/advanced.tex
@@ -33,6 +33,7 @@
 
   Problem: Manchmal führt \texttt{make} Skripte gleichzeitig zweimal aus (hier \texttt{plot.py})
   \begin{center}
+    \small
     \begin{minted}{make}
       all: report.txt
 
@@ -44,16 +45,21 @@
     \end{minted}
   \end{center}
 
-  Lösung: manuell synchronisieren
+  Lösung: Ein \texttt{make}-Feature (\texttt{v4.3}): \emph{grouped targets}
   \begin{center}
-    $\vdots$ \\
+    \small
     \begin{minted}{make}
-      plot1.pdf: plot.py data.txt
+      all: report.txt
+
+      report.txt: plot1.pdf plot2.pdf
+        touch report.txt
+
+      plot2.pdf plot1.pdf &: plot.py data.txt # das &: definiert die targets als group 
           python plot.py
 
-      plot2.pdf: plot1.pdf
     \end{minted}
   \end{center}
+   → Alle \texttt{targets} werden durch eine einzigen Durchlauf der \texttt{recipe} (gebündelt) erzeugt.
+\end{frame}
 
-  Wenn man \texttt{plot2.pdf} aber nicht \texttt{plot1.pdf} löscht, kann \texttt{make} nicht mehr \texttt{plot2.pdf} erstellen.
 \end{frame}

--- a/make/content/advanced.tex
+++ b/make/content/advanced.tex
@@ -62,4 +62,36 @@
    → Alle \texttt{targets} werden durch eine einzigen Durchlauf der \texttt{recipe} (gebündelt) erzeugt.
 \end{frame}
 
+\begin{frame}[fragile]{Expert}
+  Wenn ein Skript sehr viele Dateien erzeugt kann die Liste der \texttt{targets} unübersichtlich lang werden.\\
+  Diese \texttt{targets} werden außerdem in der Regel als \texttt{prerequisites} verwendet,
+  z.~B. für die \texttt{recipe} der Berichtdatei  → Die Liste befindet sich sogar zweimal im \texttt{Makefile}
+
+  \begin{center}
+    \small
+    \begin{minted}{make}
+      all: report.txt
+
+      report.txt: plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf
+        touch report.txt
+
+      plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf: plot.py data.txt
+        python plot.py  # plot.py produziert alle plot{i}.pdf 
+    \end{minted}
+  \end{center}
+  Lösung: Ein weiteres \texttt{make}-Feature: \emph{variables}
+  \begin{center}
+    \small
+    \begin{minted}{make}
+      all: report.txt
+
+      script_targets = plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf #Variablen Definition
+
+      report.txt: $(script_targets) #Variablen Verwendung
+        touch report.txt
+      
+      $(script_targets): plot.py data.txt #Variablen Verwendung
+          python plot.py
+    \end{minted}
+  \end{center}
 \end{frame}

--- a/make/content/advanced.tex
+++ b/make/content/advanced.tex
@@ -2,28 +2,7 @@
 
 \begin{frame}[fragile]{Vergleich: Kuchen backen}
   \begin{center}
-    \begin{minted}{make}
-    Kuchen: Teig Backofen
-        Ofen auf 140°C vorheizen
-        Teig in Backform geben und in den Ofen schieben
-        Kuchen nach 40 min herausnehmen
-
-    Teig: Eier Mehl Zucker Milch Rumrosinen | Schüssel
-        Eier schlagen
-        Mehl, Zucker und Milch hinzugeben
-        Rumrosinen unterrühren
-
-    Rumrosinen: Rum Rosinen
-        Rosinen in Rum einlegen
-        Vier Wochen stehen lassen
-
-    Schüssel:
-        Rührschüssel auf den Tisch stellen, wenn nicht vorhanden
-
-    clean:
-        Kuchen essen
-        Küche sauber machen und aufräumen
-    \end{minted}
+    \inputminted{make}{example-files/Cake}
   \end{center}
 \end{frame}
 
@@ -34,30 +13,13 @@
   Problem: Manchmal führt \texttt{make} Skripte gleichzeitig zweimal aus (hier \texttt{plot.py})
   \begin{center}
     \small
-    \begin{minted}{make}
-      all: report.txt
-
-      report.txt: plot1.pdf plot2.pdf
-        touch report.txt
-
-      plot1.pdf plot2.pdf: plot.py data.txt
-        python plot.py  # plot.py produziert sowohl plot1.pdf als auch plot2.pdf
-    \end{minted}
+    \inputminted{make}{example-files/Advanced-0}
   \end{center}
 
   Lösung: Ein \texttt{make}-Feature (\texttt{v4.3}): \emph{grouped targets}
   \begin{center}
     \small
-    \begin{minted}{make}
-      all: report.txt
-
-      report.txt: plot1.pdf plot2.pdf
-        touch report.txt
-
-      plot2.pdf plot1.pdf &: plot.py data.txt  # das &: definiert die targets als group 
-          python plot.py
-
-    \end{minted}
+    \inputminted{make}{example-files/Advanced-1}
   \end{center}
    → Alle \texttt{targets} werden durch eine einzigen Durchlauf der \texttt{recipe} (gebündelt) erzeugt.
 \end{frame}
@@ -69,30 +31,12 @@
 
   \begin{center}
     \small
-    \begin{minted}{make}
-      all: report.txt
-
-      report.txt: plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf
-        touch report.txt
-
-      plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf & : plot.py data.txt
-        python plot.py  # plot.py produziert alle plot{i}.pdf 
-    \end{minted}
+    \inputminted{make}{example-files/Advanced-2}
   \end{center}
   Lösung: Ein weiteres \texttt{make}-Feature: \emph{variables}
   \begin{center}
     \small
-    \begin{minted}{make}
-      all: report.txt
-
-      script_targets = plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf  # Variablen Definition
-
-      report.txt: $(script_targets)  # Variablen Verwendung
-        touch report.txt
-      
-      $(script_targets) & : plot.py data.txt  # Variablen Verwendung
-          python plot.py
-    \end{minted}
+    \inputminted{make}{example-files/Advanced-3}
   \end{center}
 \end{frame}
 
@@ -103,16 +47,6 @@
   \texttt{addsuffix .pdf} hängt an jeden Dateinamen die Endung \texttt{.pdf} an.
   \begin{center}
     \small
-    \begin{minted}{make}
-      all: report.txt
-
-      plots = $(addprefix build/, $(addsuffix .pdf, plot1 plot2 plot3 plot4))  # Definition
-
-      report.txt: $(plots)  # Verwendung
-        touch report.txt
-      
-      $(plots) & : plot.py data.txt  # Verwendung
-          python plot.py
-    \end{minted}
+    \inputminted{make}{example-files/Advanced-4}
   \end{center}
 \end{frame}

--- a/make/content/advanced.tex
+++ b/make/content/advanced.tex
@@ -54,7 +54,7 @@
       report.txt: plot1.pdf plot2.pdf
         touch report.txt
 
-      plot2.pdf plot1.pdf &: plot.py data.txt # das &: definiert die targets als group 
+      plot2.pdf plot1.pdf &: plot.py data.txt  # das &: definiert die targets als group 
           python plot.py
 
     \end{minted}
@@ -75,7 +75,7 @@
       report.txt: plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf
         touch report.txt
 
-      plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf: plot.py data.txt
+      plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf & : plot.py data.txt
         python plot.py  # plot.py produziert alle plot{i}.pdf 
     \end{minted}
   \end{center}
@@ -85,12 +85,33 @@
     \begin{minted}{make}
       all: report.txt
 
-      script_targets = plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf #Variablen Definition
+      script_targets = plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf  # Variablen Definition
 
-      report.txt: $(script_targets) #Variablen Verwendung
+      report.txt: $(script_targets)  # Variablen Verwendung
         touch report.txt
       
-      $(script_targets): plot.py data.txt #Variablen Verwendung
+      $(script_targets) & : plot.py data.txt  # Variablen Verwendung
+          python plot.py
+    \end{minted}
+  \end{center}
+\end{frame}
+
+\begin{frame}[fragile]{Expert}
+  Die Variablenliste kann auch weiter bearbeitet werden.
+  Mit \texttt{addprefix build/} wird in diesem Beispiel der \texttt{build} Ordner
+  an den Anfang jedes Dateipfades geschrieben.
+  \texttt{addsuffix .pdf} hängt an jeden Dateinamen die Endung \texttt{.pdf} an.
+  \begin{center}
+    \small
+    \begin{minted}{make}
+      all: report.txt
+
+      plots = $(addprefix build/, $(addsuffix .pdf, plot1 plot2 plot3 plot4))  # Definition
+
+      report.txt: $(plots)  # Verwendung
+        touch report.txt
+      
+      $(plots) & : plot.py data.txt  # Verwendung
           python plot.py
     \end{minted}
   \end{center}

--- a/make/content/build.tex
+++ b/make/content/build.tex
@@ -4,10 +4,7 @@
   (Nützliche) Konvention: \texttt{make clean} löscht alle vom \texttt{Makefile} erstellten Dateien/Ordner.
 
   \begin{center}
-    \begin{minted}{make}
-      clean:
-          rm plot.pdf report.pdf
-    \end{minted}
+    \inputminted{make}{example-files/Simple-clean}
   \end{center}
 
   Das Projekt sollte dann so aussehen, wie vor dem ersten Ausführen von \texttt{make}.
@@ -17,23 +14,7 @@
   \texttt{build}-Ordner: Projekt sauber halten
 
   \begin{center}
-    \begin{minted}{make}
-      all: build/report.pdf
-
-      build/plot.pdf: plot.py data.txt | build
-          python plot.py  # savefig('build/plot.pdf')
-
-      build/report.pdf: report.tex build/plot.pdf | build
-          lualatex --output-directory=build report.tex
-
-      build:
-          mkdir -p build
-
-      clean:
-          rm -rf build
-
-      .PHONY: all clean
-    \end{minted}
+    \inputminted{make}{example-files/First-build-dir}
   \end{center}
 
   \begin{itemize}

--- a/make/content/latexmk.tex
+++ b/make/content/latexmk.tex
@@ -51,21 +51,7 @@
 
 \begin{frame}[fragile]{\texttt{latexmk} im \texttt{Makefile}}
   \begin{block}{Im \texttt{Makefile}}
-    \begin{minted}{make}
-      build/file.pdf: FORCE plots... tabellen...
-          TEXINPUTS=build: \
-          max_print_line=1048576 \
-          latexmk \
-            --lualatex \
-            --output-directory=build \
-            --interaction=nonstopmode \
-            --halt-on-error \
-          file.tex
-
-      FORCE:
-
-      .PHONY: FORCE all clean
-    \end{minted}
+    \inputminted{make}{example-files/Latexmk}
   \end{block}
 
   \begin{itemize}

--- a/make/content/simple_start.tex
+++ b/make/content/simple_start.tex
@@ -8,11 +8,7 @@
     \item \texttt{Makefile} besteht aus Regeln (Rules):
   \end{itemize}
   \begin{block}{Rule}
-    \centering
-    \begin{minted}{make}
-      target: prerequisites
-          recipe
-    \end{minted}
+    \inputminted{make}{example-files/Basic-block}
   \end{block}
   \begin{description}
     \item[\texttt{\hphantom{prerequisites}\llap{target}}] Datei(en), die von dieser Rule erzeugt werden
@@ -26,10 +22,7 @@
 
 \begin{frame}[fragile]{Einfachstes Beispiel}
   \begin{center}
-    \begin{minted}{make}
-      plot.pdf: plot.py data.txt
-          python plot.py
-    \end{minted}
+    \inputminted{make}{example-files/Basic-block-example}
   \end{center}
   \begin{itemize}
     \item Wir wollen \texttt{plot.pdf} erzeugen (\texttt{target})
@@ -42,17 +35,7 @@
 
 \begin{frame}[fragile]{Beispiel}
   \begin{center}
-    \begin{minted}{make}
-      all: report.pdf  # convention
-
-      plot.pdf: plot.py data.txt
-          python plot.py
-
-      report.pdf: report.tex
-          lualatex report.tex
-
-      report.pdf: plot.pdf  # add prerequisite
-    \end{minted}
+    \inputminted{make}{example-files/First-report}
   \end{center}
   \vspace{1em}
 

--- a/make/example-files/Advanced-0
+++ b/make/example-files/Advanced-0
@@ -1,0 +1,7 @@
+all: report.txt
+
+report.txt: plot1.pdf plot2.pdf
+  touch report.txt
+
+plot1.pdf plot2.pdf: plot.py data.txt
+  python plot.py  # plot.py produziert sowohl plot1.pdf als auch plot2.pdf

--- a/make/example-files/Advanced-1
+++ b/make/example-files/Advanced-1
@@ -1,0 +1,7 @@
+all: report.txt
+
+report.txt: plot1.pdf plot2.pdf
+  touch report.txt
+
+plot2.pdf plot1.pdf &: plot.py data.txt  # das &: definiert die targets als group
+    python plot.py

--- a/make/example-files/Advanced-2
+++ b/make/example-files/Advanced-2
@@ -1,0 +1,7 @@
+all: report.txt
+
+report.txt: plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf
+  touch report.txt
+
+plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf & : plot.py data.txt
+  python plot.py  # plot.py produziert alle plot{i}.pdf

--- a/make/example-files/Advanced-3
+++ b/make/example-files/Advanced-3
@@ -1,0 +1,9 @@
+all: report.txt
+
+script_targets = plot1.pdf plot2.pdf plot3.pdf plot4.pdf plot5.pdf  # Variablen Definition
+
+report.txt: $(script_targets)  # Variablen Verwendung
+  touch report.txt
+
+$(script_targets) & : plot.py data.txt  # Variablen Verwendung
+  python plot.py

--- a/make/example-files/Advanced-4
+++ b/make/example-files/Advanced-4
@@ -1,0 +1,9 @@
+all: report.txt
+
+plots = $(addprefix build/, $(addsuffix .pdf, plot1 plot2 plot3 plot4))  # Definition
+
+report.txt: $(plots)  # Verwendung
+  touch report.txt
+
+$(plots) & : plot.py data.txt  # Verwendung
+  python plot.py

--- a/make/example-files/Basic-block
+++ b/make/example-files/Basic-block
@@ -1,0 +1,2 @@
+target: prerequisites
+  recipe

--- a/make/example-files/Basic-block-example
+++ b/make/example-files/Basic-block-example
@@ -1,0 +1,2 @@
+plot.pdf: plot.py data.txt
+	python plot.py

--- a/make/example-files/Cake
+++ b/make/example-files/Cake
@@ -1,0 +1,20 @@
+Kuchen: Teig Backofen
+  Ofen auf 140°C vorheizen
+  Teig in Backform geben und in den Ofen schieben
+  Kuchen nach 40 min herausnehmen
+
+Teig: Eier Mehl Zucker Milch Rumrosinen | Schüssel
+  Eier schlagen
+  Mehl, Zucker und Milch hinzugeben
+  Rumrosinen unterrühren
+
+Rumrosinen: Rum Rosinen
+  Rosinen in Rum einlegen
+  Vier Wochen stehen lassen
+
+Schüssel:
+  Rührschüssel auf den Tisch stellen, wenn nicht vorhanden
+
+clean:
+  Kuchen essen
+  Küche sauber machen und aufräumen

--- a/make/example-files/First-build-dir
+++ b/make/example-files/First-build-dir
@@ -1,0 +1,15 @@
+all: build/report.pdf
+
+build/plot.pdf: plot.py data.txt | build
+  python plot.py  # savefig('build/plot.pdf')
+
+build/report.pdf: report.tex build/plot.pdf | build
+  lualatex --output-directory=build report.tex
+
+build:
+  mkdir -p build
+
+clean:
+  rm -rf build
+
+.PHONY: all clean

--- a/make/example-files/First-report
+++ b/make/example-files/First-report
@@ -1,0 +1,9 @@
+all: report.pdf  # convention
+
+plot.pdf: plot.py data.txt
+	python plot.py
+
+report.pdf: report.tex
+	lualatex report.tex
+
+report.pdf: plot.pdf  # add prerequisite

--- a/make/example-files/Latexmk
+++ b/make/example-files/Latexmk
@@ -1,0 +1,13 @@
+build/file.pdf: FORCE plots... tabellen...
+  TEXINPUTS=build: \
+  max_print_line=1048576 \
+  latexmk \
+    --lualatex \
+    --output-directory=build \
+    --interaction=nonstopmode \
+    --halt-on-error \
+  file.tex
+
+FORCE:
+
+.PHONY: FORCE all clean

--- a/make/example-files/Simple-clean
+++ b/make/example-files/Simple-clean
@@ -1,0 +1,2 @@
+clean:
+  rm plot.pdf report.pdf


### PR DESCRIPTION
In case we want to add this small change and example to the end of the expert slides:

Changes the solution for parallelization to using grouped targets.
Adds one slide with an example for make variables.

See https://github.com/pep-dortmund/toolbox-workshop/issues/408 for details.

Personally I really do like this small addition and the look of the 'cleaner'
Makefile, but the change is not necessary.