### PR TITLE
Add pooch to environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,6 @@ dependencies:
   - nbstripout
   - black
   - black-jupyter
+  - pooch
   - pip:
     - ./pygments_style


### PR DESCRIPTION
Fixes pooch dependency for `scipy.database` module. Closes #453.